### PR TITLE
Fix the DNS resolver variables

### DIFF
--- a/pf9/config/commands.py
+++ b/pf9/config/commands.py
@@ -10,13 +10,13 @@ def config():
     """Configure Platform9 Express."""
 def manage_dns_resolvers(ctx, param, man_resolvers):
     if man_resolvers:
-        if not ctx.params['dns_resolver_1']:
-            ctx.params['dns_resolver_1'] = click.prompt('Enter DNS Resolver 1')
-        if not ctx.params['dns_resolver_2']:
-            ctx.params['dns_resolver_2'] = click.prompt('Enter DNS Resolver 2')
+        if not ctx.params['dns_resolver1']:
+            ctx.params['dns_resolver1'] = click.prompt('Enter DNS Resolver 1')
+        if not ctx.params['dns_resolver2']:
+            ctx.params['dns_resolver2'] = click.prompt('Enter DNS Resolver 2')
     else:
-        ctx.params['dns_resolver_1'] = "8.8.8.8"
-        ctx.params['dns_resolver_2'] = "8.8.4.4"
+        ctx.params['dns_resolver1'] = "8.8.8.8"
+        ctx.params['dns_resolver2'] = "8.8.4.4"
     return man_resolvers
 
 @config.command('create')
@@ -28,8 +28,8 @@ def manage_dns_resolvers(ctx, param, man_resolvers):
 @click.option('--os_tenant', required=True, prompt='Platform9 tenant', default='service')
 @click.option('--proxy_url', required=True, prompt='Proxy url for internet access', default='-')
 @click.option('--manage_hostname', required=True, prompt='Have Platform9 Express manage hostnames', default=False)
-@click.option('--dns_resolver_1', prompt='Enter DNS resolver', is_eager=True, default='')
-@click.option('--dns_resolver_2', prompt='Enter DNS resolver', is_eager=True, default='')
+@click.option('--dns_resolver1', prompt='Enter DNS resolver 1', is_eager=True, default='')
+@click.option('--dns_resolver2', prompt='Enter DNS resolver 2', is_eager=True, default='')
 @click.option('--manage_resolver', required=True, type=bool, prompt='Have Platform9 Express manage DNS resolvers', default=False, callback=manage_dns_resolvers)
 @click.pass_context
 def create(ctx, **kwargs):

--- a/pf9/modules/util.py
+++ b/pf9/modules/util.py
@@ -26,9 +26,9 @@ class Utils:
             if 'proxy_url' in line:
                 line = line.strip()
                 config.update( {'proxy_url' : line.replace('proxy_url|','')} )
-            if 'dns_resolver_1' in line:
+            if 'dns_resolver1' in line:
                 line = line.strip()
-                config.update( {'dns_resolver_1' : line.replace('dns_resolver_1|','')} )
+                config.update( {'dns_resolver1' : line.replace('dns_resolver1|','')} )
             if 'dns_resolver_2' in line:
                 line = line.strip()
                 config.update( {'dns_resolver_2' : line.replace('dns_resolver_2|','')} )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,8 +79,8 @@ class TestConfigCreate(TestCase):
                 os_region|region1
                 os_username|test.user@platform9.com
                 proxy_url|-
-                dns_resolver_1|1.1.1.1
-                dns_resolver_2|2.2.2.2
+                dns_resolver1|1.1.1.1
+                dns_resolver2|2.2.2.2
                 du_url|test.user@platform9.com
                 manage_hostname|TRUE
                 manage_resolver|True
@@ -105,8 +105,8 @@ class TestConfigCreate(TestCase):
                     '--proxy_url=-', 
                     '--manage_hostname=TRUE', 
                     '--manage_resolver=True', 
-                    '--dns_resolver_1=1.1.1.1', 
-                    '--dns_resolver_2=2.2.2.2'], 
+                    '--dns_resolver1=1.1.1.1', 
+                    '--dns_resolver2=2.2.2.2'], 
                 obj=self.obj_test)
 # !!! Need to compaire elements of both config files
 # !!! They are strings so either readline and evaluate each against other file or split('\n', list).sort()
@@ -134,8 +134,8 @@ class TestConfigList(TestCase):
                 os_region|region1
                 os_username|test.user@platform9.com
                 proxy_url|-
-                dns_resolver_1|1.1.1.1
-                dns_resolver_2|2.2.2.2
+                dns_resolver1|1.1.1.1
+                dns_resolver2|2.2.2.2
                 du_url|test.user@platform9.com
                 manage_hostname|TRUE
                 manage_resolver|True


### PR DESCRIPTION
The pf9-express config file expects the DNS resolver config variable to be
dns_resolver1 and dns_resolver2. The express cli had a typo when it can creating
this config file. It was building files with dns_resolver_1 and dns_resolver_2.
This change fixes it.