### PR TITLE
Initial cut of the CLI setup script

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+
+set -xo pipefail
+
+flag_testsetup=0
+log=/tmp/pf9-cli-setup.log
+cli_setup_dir=/opt/pf9/cli
+
+
+install_prereqs() {
+    echo -n "--> Validating package dependencies: "
+    if [ "${platform}" == "ubuntu" ]; then
+    # add ansible repository
+        dpkg-query -f '${binary:Package}\n' -W | grep ^ansible$ > /dev/null 2>&1
+        if [ $? -ne 0 ]; then
+            sudo apt-add-repository -y ppa:ansible/ansible > /dev/null 2>&1
+            sudo apt-get update> /dev/null 2>&1
+            sudo apt-get -y install ansible >> ${log} 2>&1
+            if [ $? -ne 0 ]; then
+            echo -e "\nERROR: failed to install ${pkg} - here's the last 10 lines of the log:\n"
+            tail -10 ${log}; exit 1
+            fi
+        fi
+
+        for pkg in jq bc; do
+            echo -n "${pkg} "
+            dpkg-query -f '${binary:Package}\n' -W | grep ^${pkg}$ > /dev/null 2>&1
+            if [ $? -ne 0 ]; then
+            sudo apt-get -y install ${pkg} >> ${log} 2>&1
+            if [ $? -ne 0 ]; then
+                echo -e "\nERROR: failed to install ${pkg} - here's the last 10 lines of the log:\n"
+                tail -10 ${log}; exit 1
+            fi
+            fi
+        done
+
+        ## upgrade pip
+        sudo ${cli_setup_dir}/bin/pip install --upgrade pip >> ${log} 2>&1
+        if [ $? -ne 0 ]; then
+            echo -e "\nERROR: failed to upgrade pip - here's the last 10 lines of the log:\n"
+            tail -10 ${log}; exit 1
+        fi
+
+        ## install additional pip-based packages
+        for pkg in shade; do
+            echo -n "${pkg} "
+            sudo ${cli_setup_dir}/bin/pip install ${pkg} --ignore-installed >> ${log} 2>&1
+            if [ $? -ne 0 ]; then
+            echo -e "\nERROR: failed to install ${pkg} - here's the last 10 lines of the log:\n"
+            tail -10 ${log}; exit 1
+            fi
+        done
+        echo
+    else
+        echo -e "\nERROR: Unsupported platform ${platform}"; exit 1
+    fi
+
+    # create log directory
+    if [ ! -d /var/log/pf9 ]; then sudo mkdir -p /var/log/pf9; fi
+}
+
+validate_platform() {
+  # check if running CentOS 7, Ubuntu 16.04, or Ubuntu 18.04
+  if [ -r /etc/centos-release ]; then
+    release=$(cat /etc/centos-release | cut -d ' ' -f 4)
+    if [[ ! "${release}" == 7.* ]]; then assert "unsupported CentOS release: ${release}"; fi
+    platform="centos"
+    host_os_info=$(cat /etc/centos-release)
+  elif [ -r /etc/lsb-release ]; then
+    release=$(cat /etc/lsb-release | grep ^DISTRIB_RELEASE= /etc/lsb-release | cut -d '=' -f2)
+    if [[ ! "${release}" == 16.04* ]] && [[ ! "${release}" == 18.04* ]]; then assert "unsupported Ubuntu release: ${release}"; fi
+    platform="ubuntu"
+    ubuntu_release=$(cat /etc/lsb-release | grep ^DISTRIB_RELEASE | cut -d = -f2)
+    host_os_info="${platform} ${ubuntu_release}"
+  else
+    assert "unsupported platform"
+  fi
+}
+
+ensure_py_pip_setup() {
+    py3_exec=$(which python3)
+    if [ $? -eq 0 ]; then
+        use_py3=1
+        py_exec=${py3_exec}
+    else
+        py2_exec=$(which python2)
+        if [ $? -ne 0 ]; then
+            # report no python error and quit
+            echo "Ayyyoooo"
+        fi
+        py_exec=${py2_exec}
+    fi
+
+    #Install pip if not present
+    if [ ${use_py3} -eq 1 ]; then
+        pip3_exec=$(which pip3)
+        if [ $? -ne 0 ]; then
+            #YUCK.. Need this hack for Ubuntu16.04
+            if [ "${platform}" == "ubuntu" ]; then
+                sudo apt-get -y install python3-venv
+            fi
+            # TODO: Error handling
+            curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+            ${py3_exec} /tmp/get-pip.py
+        fi
+    else
+        pip2_exec=$(which pip)
+        if [ $? -ne 0 ]; then
+            # TODO: Error handling
+            curl https://bootstrap.pypa.io/get-pip.py -o /tmp/get-pip.py
+            ${py2_exec} /tmp/get-pip.py
+            venv_exec=$(which virtualenv)
+            if [ $? -ne 0 ]; then
+                # TODO: Error handling
+                ${pip2_exec} install virtualenv
+            fi
+        fi
+    fi
+}
+
+setup_venv() {
+    sudo mkdir -p ${cli_setup_dir}
+    if [ ${use_py3} -eq 1 ]; then
+        # TODO: Error handling
+        sudo ${py3_exec} -m venv ${cli_setup_dir}
+    else
+        # TODO: Error handling
+        sudo ${py2_exec} -m virtualenv ${cli_setup_dir}
+    fi
+}
+
+setup_express() {
+    echo "################################### Install express cli ########################################"
+    if [ ${flag_testsetup} -eq 1 ]; then
+        # Dependencies are not well handled with the test pypi. Install explicityly first.
+        # TODO: Explore if there is a better way to handle dependencies like below
+        sudo ${cli_setup_dir}/bin/pip install click requests prettytable
+        sudo ${cli_setup_dir}/bin/pip install --index-url https://test.pypi.org/simple/ express-cli
+    else
+        sudo ${cli_setup_dir}/bin/pip install express-cli
+    fi
+
+    if [ $? != '0' ]
+    then
+        echo "express-cli installation failed"
+        exit 1
+    fi
+
+    echo "############################ Initializing Platform9 Express CLI ################################"
+    ${cli_setup_dir}/bin/express init
+
+    echo "########################### Configuring the CLI to use your account #############################"
+    read -p "Platform9 account FQDN: " DUFQDN
+    read -p "Platform9 region: " REGION
+    read -p "Platform9 username: " USER
+    read -sp "Platform9 user password: " PASS
+    read -p "Platform9 user tenant: " PROJECT
+    ${cli_setup_dir}/bin/express config create --config_name ${configname} --du_url ${DUFQDN} --os_username ${USER} --os_password ${PASS} --os_region ${REGION} --os_tenant {PROJECT}
+
+    #TODO: Create symlink to the exec
+}
+
+while [ $# -gt 0 ]; do
+    case ${1} in
+    -t|--test)
+        flag_testsetup=1 
+    ;;
+    -l|--log)
+        log=${2}
+        shift
+    esac
+    shift
+done
+
+echo >> ${log} 2>&1
+echo "######################################" >> ${log} 2>&1
+echo "Start install of Platform9 CLI $(date)" >> ${log} 2>&1
+process_inputs
+validate_platform
+ensure_py_pip_setup
+setup_venv
+
+# All operations below occur inside the venv
+install_prereqs
+setup_express


### PR DESCRIPTION
A setup script to prep the express CLI. Many of its current implementation is
heavily inspired by the pf9-express setup process. In short the script does
following
- Check the platform (currenly supporting only Ubuntu)
- Check if py3 is available (first preference to use this), else use py2
- Ensure the right pip is installed.
- Create a venv in /opt/pf9/cli based on py2/py3 method
- Install some pre-reqs like ansible, jq, shade
- Install express-cli in the venv
- Run express init
- Run express config and ask for the DU creds. We want a config to be created
right away for the end user.

These steps are optimized for PMK at the moment because that is the first target
for the CLI.

Note that there is a test setup flag (-t) which will pull express from
test.pypi.org. That is where we stage intermediate versions of the express-cli
before release.

It is not polished enough yet but this should be a good place for users to play
around with this.
- Has command echo for debugging purposes.
- Logging of the setup needs to be standardized
- Some command failure handling is missing.
- Sym link to the exec itself to make it part of the user's PATH is not done