### PR TITLE
Make which platform is supported more obvious. 

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -34,7 +34,7 @@ install_prereqs() {
             fi
         done
     else
-        echo -e "\nERROR: Unsupported platform ${platform}. Please use an ubuntu platform"; exit 1
+        echo -e "\nERROR: Unsupported platform ${platform}. Please use an Ubuntu 16.04 platform"; exit 1
     fi
 }
 

--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -34,7 +34,7 @@ install_prereqs() {
             fi
         done
     else
-        echo -e "\nERROR: Unsupported platform ${platform}"; exit 1
+        echo -e "\nERROR: Unsupported platform ${platform}. Please use an ubuntu platform"; exit 1
     fi
 }
 


### PR DESCRIPTION
Currently the install script just shows that the platform is wrong, without specifying which platform the user needs to use. 