### PR TITLE
Incremental version of CLI fit and finish

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -150,7 +150,7 @@ setup_express() {
     if [ ${flag_testsetup} -eq 1 ]; then
         # Dependencies are not well handled with the test pypi. Install explicityly first.
         # TODO: Explore if there is a better way to handle dependencies like below
-        sudo ${cli_setup_dir}/bin/pip install click requests prettytable
+        sudo ${cli_setup_dir}/bin/pip install click requests prettytable netifaces colorama click-spinner
         sudo ${cli_setup_dir}/bin/pip install --index-url https://test.pypi.org/simple/ express-cli
     else
         sudo ${cli_setup_dir}/bin/pip install express-cli
@@ -173,6 +173,7 @@ setup_express() {
     read -p "Platform9 user tenant: " PROJECT
     ${cli_setup_dir}/bin/express config create --config_name pf9-express ${configname} --du ${DUFQDN} --os_username ${USER} --os_password ${PASS} --os_region ${REGION} --os_tenant ${PROJECT}
     sudo ln -s ${cli_setup_dir}/bin/express /usr/bin/express
+    sudo ln -s ${cli_setup_dir}/bin/express /usr/bin/pf9ctl
 }
 
 while [ $# -gt 0 ]; do

--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -150,7 +150,7 @@ setup_express() {
     if [ ${flag_testsetup} -eq 1 ]; then
         # Dependencies are not well handled with the test pypi. Install explicityly first.
         # TODO: Explore if there is a better way to handle dependencies like below
-        sudo ${cli_setup_dir}/bin/pip install click requests prettytable netifaces colorama click-spinner
+        sudo ${cli_setup_dir}/bin/pip install click requests prettytable netifaces colorama
         sudo ${cli_setup_dir}/bin/pip install --index-url https://test.pypi.org/simple/ express-cli
     else
         sudo ${cli_setup_dir}/bin/pip install express-cli

--- a/pf9/cluster/cluster_attach.py
+++ b/pf9/cluster/cluster_attach.py
@@ -117,8 +117,8 @@ class AttachCluster(object):
         for host in json_response:
             if not 'extensions' in host:
                 continue
-            for key, value in host['extensions']['interfaces']['data'].iteritems():
-                for iface_name, iface_ip in host['extensions']['interfaces']['data']['iface_ip'].iteritems():
+            for key, value in host['extensions']['interfaces']['data'].items():
+                for iface_name, iface_ip in host['extensions']['interfaces']['data']['iface_ip'].items():
                     if iface_ip == host_ip:
                         return(host['id'])
 

--- a/pf9/cluster/cluster_create.py
+++ b/pf9/cluster/cluster_create.py
@@ -30,7 +30,7 @@ class CreateCluster(object):
     def get_nodepool_id(self):
         try:
             api_endpoint = "qbert/v3/{}/cloudProviders".format(self.project_id)
-            pf9_response = requests.get("{}/{}".format(self.du_url,api_endpoint), verify=False, headers=self.headers)
+            pf9_response = requests.get("{}/{}".format(self.du_url,api_endpoint), headers=self.headers)
             if pf9_response.status_code != 200:
                 return None
 
@@ -77,7 +77,7 @@ class CreateCluster(object):
         # create cluster (post to qbert)
         try:
             api_endpoint = "qbert/v3/{}/clusters".format(self.project_id)
-            pf9_response = requests.post("{}/{}".format(self.du_url,api_endpoint), verify=False, headers=self.headers, data=json.dumps(cluster_create_payload))
+            pf9_response = requests.post("{}/{}".format(self.du_url,api_endpoint), headers=self.headers, data=json.dumps(cluster_create_payload))
         except:
             self.fail_bootstrap("failed to create cluster")
 
@@ -92,7 +92,7 @@ class CreateCluster(object):
     def cluster_exists(self):
         try:
             api_endpoint = "qbert/v3/{}/clusters".format(self.project_id)
-            pf9_response = requests.get("{}/{}".format(self.du_url,api_endpoint), verify=False, headers=self.headers)
+            pf9_response = requests.get("{}/{}".format(self.du_url,api_endpoint), headers=self.headers)
             if pf9_response.status_code != 200:
                 return False, None
         except:

--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -1,4 +1,5 @@
 import click
+from datetime import datetime
 import os
 from prettytable import PrettyTable
 import shlex
@@ -6,11 +7,18 @@ from string import Template
 import subprocess
 import sys
 import tempfile
+import time
+from ..exceptions import CLIException, PrepNodeFailed
+from .helpers import validate_ssh_details, get_local_node_addresses, check_vip_needed
 from ..modules.ostoken import GetToken
 from ..modules.util import GetConfig 
 from ..modules.util import Utils
 from .cluster_create import CreateCluster
 from .cluster_attach import AttachCluster
+
+def print_help_msg(command):
+    with click.Context(command) as ctx:
+        click.echo(command.get_help(ctx))
 
 def run_command(command, run_env=os.environ):
     try:
@@ -21,14 +29,49 @@ def run_command(command, run_env=os.environ):
         click.echo('%s command failed: %s', command, e)
         return e.returncode, e.output
 
-def run_express(ctx, inv_file):
+def run_express(ctx, inv_file, ips):
     # Build the pf9-express command to run
     exp_ansible_runner = os.path.join(ctx.obj['pf9_exp_dir'], 'express', 'pf9-express')
     exp_config_file = os.path.join(ctx.obj['pf9_exp_dir'], 'config', 'express.conf')
+    log_file = os.path.join("/var/log/pf9",
+                            datetime.now().strftime('express_%Y_%m_%d-%H_%m_%S.log'))
     # Invoke PMK only related playbook.
+    #cmd = 'sudo {0} -a -b --pmk -v {1} -c {2} -l {3} pmk'.format(exp_ansible_runner,
+    #                                               inv_file, exp_config_file, log_file)
+
     cmd = 'sudo {0} -a -b --pmk -v {1} -c {2} pmk'.format(exp_ansible_runner,
                                                    inv_file, exp_config_file)
-    return run_command(cmd)
+    # Current implementation is to have this express invocation dumps logs in 
+    # a known location instead of capturing it here. Here we care only about
+    # the exit code and fake progress.
+
+    # Progress bar logic: Assume each host takes x time. Number of hosts is n
+    # Total estimated time = n * x. We check for command status and refresh the
+    # bar even ys with n*x/y.
+    time_per_host_secs = 240
+    total_nodes = len(ips)
+    poll_interval_secs = 5
+    with click.progressbar(length=total_nodes * time_per_host_secs, color="orange",
+                           label='Preparing nodes') as bar:
+        cmd_proc = subprocess.Popen(shlex.split(cmd), env=os.environ, stdout=subprocess.PIPE,
+                                    stderr=subprocess.PIPE)
+        elapsed = 0
+        while cmd_proc.poll() is None:
+            elapsed =  elapsed + poll_interval_secs
+            if elapsed < (total_nodes * time_per_host_secs - poll_interval_secs):
+                bar.update(poll_interval_secs)
+                time.sleep(poll_interval_secs)
+
+        # Success or failure... push the progress to 100%
+        bar.update(total_nodes * time_per_host_secs)
+
+    if cmd_proc.returncode:
+        msg = "Error while preparing nodes. Code: {}, output log: {}".format(
+                                            cmd_proc.returncode, log_file)
+        raise PrepNodeFailed(msg)
+
+    return cmd_proc.returncode, log_file
+
 
 # NOTE: a utils file may be a better location for these helper methods
 def build_express_inventory_file(ctx, user, password, ssh_key, ips,
@@ -58,10 +101,10 @@ def build_express_inventory_file(ctx, user, password, ssh_key, ips,
                     node_info = 'localhost ansible_python_interpreter=/opt/pf9/cli/bin/python ansible_connection=local ansible_host=localhost\n'
                 else:
                     if password:
-                        node_info = "{0} ansible_python_interpreter=/opt/pf9/cli/bin/python ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_user={1} ansible_ssh_pass={2}\n".format(
+                        node_info = "{0} ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_user={1} ansible_ssh_pass={2}\n".format(
                                      ip, user, password)
                     else:
-                        node_info = "{0} ansible_python_interpreter=/opt/pf9/cli/bin/python ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_user={1} ansible_ssh_private_key_file={2}\n".format(
+                        node_info = "{0} ansible_ssh_common_args='-o StrictHostKeyChecking=no' ansible_user={1} ansible_ssh_private_key_file={2}\n".format(
                                      ip, user, ssh_key)
                 node_details = "".join((node_details, node_info))
 
@@ -93,11 +136,11 @@ def get_token_project(ctx):
 def create_cluster(ctx):
     
     # create cluster
-    click.echo("[Creating Cluster: {}]".format(ctx.params['cluster_name']))
+    click.echo("Creating Cluster: {}".format(ctx.params['cluster_name']))
     cluster_status, cluster_uuid = CreateCluster(ctx).cluster_exists()
         
     if cluster_status == True:
-        click.echo("cluster already exists")
+        click.echo("Cluster {} already exists".format(ctx.params['cluster_name']))
     else:
         CreateCluster(ctx).create_cluster()
         cluster_uuid = CreateCluster(ctx).wait_for_cluster()
@@ -105,45 +148,47 @@ def create_cluster(ctx):
     return cluster_uuid
 
 
-def attach_cluster(ctx):
+def attach_cluster(cluster_name, master_ips, worker_ips, ctx):
     # Attach to cluster
     cluster_attacher = AttachCluster(ctx)
-    cluster_name = ctx.params['cluster_name']
 
-    click.echo("[Attaching to cluster {}]".format(cluster_name))
+    click.echo("Attaching to cluster {}".format(cluster_name))
     status, cluster_uuid = cluster_attacher.cluster_exists(cluster_name)
 
     if status == False:
-        click.echo("Cluster {} doesn't exist. Provide name of an existing cluster".format(
-                    ctx.params['cluster_name']))
-        # TODO: How should the error be handled?
+        click.secho("Cluster {} doesn't exist. Provide name of an existing cluster".format(
+                    ctx.params['cluster_name']), fg="red")
         sys.exit(1)
 
-    master_ips = ctx.params['master_ip']
-    master_nodes = cluster_attacher.get_uuids(master_ips)
-    click.echo("[Discovering UUIDs for Cluster Nodes]")
-    click.echo("--> Master Nodes")
-    for node in master_nodes:
-        click.echo("{}".format(node))
+    if master_ips:
+        master_nodes = cluster_attacher.get_uuids(master_ips)
+        click.echo("Discovering UUIDs for cluster's master nodes")
+        click.echo("Master nodes: ")
+        for node in master_nodes:
+            click.echo("{}".format(node))
 
     # get uuids for worker nodes
-    worker_ips = ctx.params['worker_ip']
-    worker_nodes = cluster_attacher.get_uuids(worker_ips)
-    click.echo("--> Worker Nodes")
-    for node in worker_nodes:
-        click.echo("{}".format(node))
+    if worker_ips:
+        worker_nodes = cluster_attacher.get_uuids(worker_ips)
+        click.echo("Worker Nodes:")
+        for node in worker_nodes:
+            click.echo("{}".format(node))
 
     # wait for cluster to by ready
-    click.echo("\n[Attaching to Cluster: {}]".format(cluster_name))
+    click.echo("Attaching to cluster: {}".format(cluster_name))
     #TODO: Why is this even required??
     cluster_uuid = cluster_attacher.wait_for_cluster(cluster_name)
 
     # attach master nodes
-    cluster_attacher.attach_to_cluster(cluster_uuid, 'master', master_nodes)
-    cluster_attacher.wait_for_n_active_masters(cluster_name, len(master_nodes))
+    #TODO: Can this fail?
+    #TODO: Likely needs a progress bar?
+    if master_ips:
+        cluster_attacher.attach_to_cluster(cluster_uuid, 'master', master_nodes)
+        cluster_attacher.wait_for_n_active_masters(cluster_name, len(master_nodes))
 
     # attach worker nodes
-    cluster_attacher.attach_to_cluster(cluster_uuid, 'worker', worker_nodes)
+    if worker_ips:
+        cluster_attacher.attach_to_cluster(cluster_uuid, 'worker', worker_nodes)
 
 
 def prep_node(ctx, user, password, ssh_key, ips, node_prep_only):
@@ -154,34 +199,34 @@ def prep_node(ctx, user, password, ssh_key, ips, node_prep_only):
 
     inv_file = build_express_inventory_file(ctx, user, password, ssh_key, ips,
                                             only_local_node, node_prep_only)
-    rcode, output = run_express(ctx, inv_file)
+    rcode, output_file = run_express(ctx, inv_file, ips)
 
-    return rcode, output
+    return rcode, output_file
 
 @click.group()
 def cluster():
-    """Platform9 Managed Kuberenetes Cluster"""
+    """Platform9 Managed Kuberenetes cluster operations"""
 
-@cluster.command('bootstrap')
+@cluster.command('create')
 @click.argument('cluster_name')
 @click.option('--masterVip', help='IP address for VIP for master nodes', default='')
-@click.option('--masterVipIf', help='Interface name for master/worker node', default='')
+@click.option('--masterVipIf', help='Interface name on which the VIP should bind to', default='')
 @click.option('--metallbCidr', help='IP range for MetalLB (<startIP>-<endIp>)', default='')
 @click.option('--containersCidr', type=str, required=False, default='10.20.0.0/16', help="CIDR for container overlay")
 @click.option('--servicesCidr', type=str, required=False, default='10.21.0.0/16', help="CIDR for services overlay")
 @click.option('--externalDnsName', type=str, required=False, default='', help="External DNS name for master VIP")
 @click.option('--privileged', type=bool, required=False, default=True, help="Enable privileged mode for Kubernetes API")
-@click.option('--appCatalogEnabled', type=bool, required=False, default=False, help="Enable Helm application catalog")
+@click.option('--appCatalogEnabled', type=bool, required=False, default=True, help="Enable Helm application catalog")
 @click.option('--allowWorkloadsOnMaster', type=bool, required=False, default=False, help="Taint master nodes (to enable workloads)")
 @click.option("--networkPlugin", type=str, required=False, default='flannel', help="Specify non-default network plugin (default = flannel)")
 @click.option('--user', '-u', help='Username for node.')
 @click.option('--password', '-p', help='Password for node if different than cluster default.')
 @click.option('--ssh-key', '-s', help='SSH key for node if different than cluster default.')
-@click.option('--master-ip', '-m', multiple=True, help='IPs of the master nodes.', prompt="IP of the master node", default='localhost') #Confirm this behavior
+@click.option('--master-ip', '-m', multiple=True, help='IPs of the master nodes.', required=True)
 @click.option('--worker-ip', '-w', multiple=True, help='IPs of the worker nodes.', default='')
 @click.pass_context
-def bootstrap(ctx, **kwargs):
-    """Create a Kubernetes cluster."""
+def create(ctx, **kwargs):
+    """Create a Kubernetes cluster"""
 
     master_ips = ctx.params['master_ip']
     ctx.params['master_ip'] = ''.join(master_ips).split(' ') if all(len(x)==1 for x in master_ips) else list(master_ips)
@@ -194,33 +239,69 @@ def bootstrap(ctx, **kwargs):
         ctx.params['worker_ip'] = ''.join(worker_ips).split(' ') if all(len(x)==1 for x in worker_ips) else list(worker_ips)
         all_ips = all_ips + ctx.params['worker_ip']
 
-    # Do input validation
-    ctx.params['token'], ctx.params['project_id'] = get_token_project(ctx)
+    try:
+        check_vip_needed(ctx.params['master_ip'], ctx.params.get('masterVip', None),
+                         ctx.params.get('masterVipIf', None))
 
-    if len(all_ips) > 0:
-        # Nodes are provided. So prep them.
-        adj_ips = ()
-        for ip in all_ips:
-            if ip == "127.0.0.1" or ip == "localhost" \
-                or ip in Utils().get_local_node_addresses():
+        ctx.params['token'], ctx.params['project_id'] = get_token_project(ctx)
 
-                adj_ips = adj_ips + ("localhost",)
-            else:
-                adj_ips = adj_ips + (ip,)
-            rcode, output = prep_node(ctx, ctx.params['user'], ctx.params['password'],
-                                    ctx.params['ssh_key'], adj_ips,
-                                    node_prep_only=True)
+        if len(all_ips) > 0:
+            # Nodes are provided. So prep them.
+            adj_ips = ()
+            for ip in all_ips:
+                if ip == "127.0.0.1" or ip == "localhost" or \
+                        ip in get_local_node_addresses():
+                    # Have to adjust this to localhost to ensure Ansible handles
+                    # this as a local connection.
+                    adj_ips = adj_ips + ("localhost",)
+                else:
+                    # check if ssh creds are provided.
+                    validate_ssh_details(ctx.params['user'], 
+                                         ctx.params['password'],
+                                         ctx.params['ssh_key'])
+                    adj_ips = adj_ips + (ip,)
 
-    cluster_uuid = create_cluster(ctx)
-    click.echo("--> Cluster UUID = {}".format(cluster_uuid))
+            # Will throw in case of failed run
+            rcode, out_file = prep_node(ctx, ctx.params['user'], ctx.params['password'],
+                                        ctx.params['ssh_key'], adj_ips,
+                                        node_prep_only=True)
 
-    # TODO: Probably users should never specify localhost, 127.0.0.1.
-    if len(all_ips) > 0:
-        # Attach nodes
-        attach_cluster(ctx)
+        cluster_uuid = create_cluster(ctx)
+        click.echo("Cluster UUID: {}".format(cluster_uuid))
+
+        if len(all_ips) > 0:
+            # To attach nodes, we have to find the node uuid from the DU based on
+            # the IP address. This cannot be localhost, 127.0.0.1. We handle it by 
+            # getting all the non local IPs and picking the first one.
+            # Attach nodes
+            master_ips = ()
+            worker_ips = ()
+            for ip in ctx.params['master_ip']:
+                if ip == "127.0.0.1" or ip == "localhost":
+                    local_ip = get_local_node_addresses()
+                    master_ips = master_ips + (local_ip[0],)
+                else:
+                    master_ips = master_ips + (ip,)
+
+            for ip in ctx.params['worker_ip']:
+                if ip == "127.0.0.1" or ip == "localhost":
+                    local_ip = get_local_node_addresses()
+                    worker_ips = worker_ips + (local_ip[0],)
+                else:
+                    worker_ips = worker_ips + (ip,)
+
+            attach_cluster(ctx.params['cluster_name'], master_ips, worker_ips, ctx)
+    except CLIException as e:
+        click.secho("Failed to create cluster {}. {}".format(
+                    ctx.params['cluster_name'], e.msg), fg="red")
+        sys.exit(1)
+    else:
+        click.secho("Successfully created cluster {} "\
+                    "using this node".format(ctx.params['cluster_name']),
+                    fg="green")
 
 
-@cluster.command('create')
+@cluster.command('bootstrap')
 @click.argument('cluster_name')
 @click.option('--masterVip', help='IP address for VIP for master nodes', default='')
 @click.option('--masterVipIf', help='Interface name for master/worker node', default='')
@@ -229,14 +310,51 @@ def bootstrap(ctx, **kwargs):
 @click.option('--servicesCidr', type=str, required=False, default='10.21.0.0/16', help="CIDR for services overlay")
 @click.option('--externalDnsName', type=str, required=False, default='', help="External DNS name for master VIP")
 @click.option('--privileged', type=bool, required=False, default=True, help="Enable privileged mode for Kubernetes API")
-@click.option('--appCatalogEnabled', type=bool, required=False, default=False, help="Enable Helm application catalog")
-@click.option('--allowWorkloadsOnMaster', type=bool, required=False, default=False, help="Taint master nodes (to enable workloads)")
+@click.option('--appCatalogEnabled', type=bool, required=False, default=True, help="Enable Helm application catalog")
+@click.option('--allowWorkloadsOnMaster', type=bool, required=False, default=True, help="Taint master nodes (to enable workloads)")
 @click.option("--networkPlugin", type=str, required=False, default='flannel', help="Specify non-default network plugin (default = flannel)")
 @click.pass_context
-def create(ctx, **kwargs):
-    ctx.params['token'], ctx.params['project_id'] = get_token_project(ctx)
-    cluster_uuid = create_cluster(ctx)
-    click.echo("--> Cluster UUID = {}".format(cluster_uuid))
+def bootstrap(ctx, **kwargs):
+    """
+    Bootstrap a single node Kubernetes cluster with your current host as the Kubernetes node.
+    """
+    prompt_msg = "Proceed with creating a Kubernetes cluster with the current node as the Kubernetes master [y/n]?"
+    localnode_confirm = click.prompt(prompt_msg, default='y')
+
+    if localnode_confirm.lower() == 'n':
+        click.secho("Quitting...", fg="red")
+        sys.exit(1)
+
+    try:
+        ctx.params['token'], ctx.params['project_id'] = get_token_project(ctx)
+
+        rcode, output = prep_node(ctx, None, None,
+                                None, ('localhost',),
+                                node_prep_only=True)
+
+        if rcode:
+            #TODO: Should we put logs somewhere?
+            click.secho("Encountered an error while preparing the local node as a Kubernetes node.",
+                        fg="red")
+
+        cluster_uuid = create_cluster(ctx)
+        click.echo("Cluster UUID: {}".format(cluster_uuid))
+
+        local_ip = get_local_node_addresses()
+        # To attach nodes, we have to find the node uuid from the DU based on
+        # the IP address. This cannot be localhost, 127.0.0.1. We handle it by 
+        # getting all the non local IPs and picking the first one
+        # Attach nodes
+        attach_cluster(ctx.params['cluster_name'], (local_ip[0],), None, ctx)
+    except CLIException as e:
+        #TODO: Should we put logs somewhere?
+        click.secho("Encountered an error while bootstrapping the local node to a Kubernetes cluster.",
+                    fg="red")
+        sys.exit(1)
+    else:
+        click.secho("Successfully created cluster {} "\
+                    "using this node".format(ctx.params['cluster_name']),
+                    fg="green")
 
 
 @cluster.command('attach-node')
@@ -245,30 +363,84 @@ def create(ctx, **kwargs):
 @click.option('--worker-ip', '-w', multiple=True, help='IP of the node to be added as workers')
 @click.pass_context
 def attach_node(ctx, **kwargs):
+    """
+    Attach provided nodes the specified cluster
+    """
+    if not ctx.params['master_ip'] and not ctx.params['worker_ip']:
+        msg = "No nodes were specified to be attached to the cluster {}."
+        click.secho(msg.format(ctx.params['cluster_name']), fg="red")
+        sys.exit(1)
+
     ctx.params['token'], ctx.params['project_id'] = get_token_project(ctx)
-    attach_cluster(ctx)
+    master_ips = ()
+    worker_ips = ()
+    for ip in ctx.params['master_ip']:
+        if ip == "127.0.0.1" or ip == "localhost":
+            local_ip = get_local_node_addresses()
+            master_ips = master_ips + (local_ip[0],)
+        else:
+            master_ips = master_ips + (ip,)
+
+    for ip in ctx.params['worker_ip']:
+        if ip == "127.0.0.1" or ip == "localhost":
+            local_ip = get_local_node_addresses()
+            worker_ips = worker_ips + (local_ip[0],)
+        else:
+            worker_ips = worker_ips + (ip,)
+
+    # There may be 0 masters, workers specified. The attach_cluster method
+    # handles this situation
+    attach_cluster(ctx.params['cluster_name'], master_ips, worker_ips, ctx)
+
 
 @cluster.command('prep-node')
-@click.option('--user', '-u', help='Username for node.')
-@click.option('--password', '-p', help='Password for node if different than cluster default.')
-@click.option('--ssh-key', '-s', help='SSH key for node if different than cluster default.')
-@click.option('--ips', '-i', multiple=True, help='IPs of the host to be prepped.', prompt="IP of the node to be prepped", default=('localhost',))
+@click.option('--user', '-u', help='SSH username for nodes.')
+@click.option('--password', '-p', help='SSH password for nodes.')
+@click.option('--ssh-key', '-s', help='SSH key for nodes.')
+@click.option('--ips', '-i', multiple=True, help='IPs of the host to be prepped.')
 @click.pass_context
 def prepnode(ctx, user, password, ssh_key, ips):
+    """ 
+    Prepare a node to be ready to be added to a Kubernetes cluster
+    """
+    if not ips:
+        prompt_msg = "No IPs provided. Proceed with preparing the current node to be added to a Kubernetes cluster [y/n]?"
 
-    # Oversmart click does some bs processing if the multiple value option (ips)
-    # has just one value provided. Seriously! - Need this work around.
-    parse_ips = ''.join(ips).split(' ') if all(len(x)==1 for x in ips) else ips
-    adj_ips = ()
-    for ip in parse_ips:
-        if ip == "127.0.0.1" or ip == "localhost" \
-            or ip in Utils().get_local_node_addresses():
-
-            adj_ips = adj_ips + ("localhost",)
+        localnode_confirm = click.prompt(prompt_msg, default = 'y')
+        if prompt_msg.lower() == 'n':
+            sys.exit(1)
         else:
-            adj_ips = adj_ips + (ip,)
+            ips = ("localhost",)
 
-    rcode, output = prep_node(ctx, user, password, ssh, key,
-                              adj_ips, node_prep_only=True)
+    # Click does some processing if the multiple value option (ips)
+    # has just one value provided. Hence, need this work around.
+    parse_ips = ''.join(ips).split(' ') if all(len(x)==1 for x in ips) else list(ips)
+    adj_ips = ()
+    try:
+        for ip in parse_ips:
+            if ip == "127.0.0.1" or ip == "localhost" \
+                or ip in Utils().get_local_node_addresses():
+                adj_ips = adj_ips + ("localhost",)
+            else:
+                # check if ssh creds are provided.
+                try:
+                    validate_ssh_details(user, password, ssh_key)
+                except CLIException as e:
+                    click.secho(e.msg, fg="red")
+                    print_help_msg(prepnode)
+                    sys.exit(1)
 
-    #TODO: Report success/failure
+                adj_ips = adj_ips + (ip,)
+
+        rcode, output_file = prep_node(ctx, user, password, ssh_key,
+                                    adj_ips, node_prep_only=True)
+
+    except CLIException as e:
+        #TODO: Should we put logs somewhere?
+        click.secho("Encountered an error while preparing the provided nodes as a Kubernetes nodes.",
+                    fg="red")
+        sys.exit(1)
+    else:
+        click.secho("Preparing the provided nodes to be added to Kubernetes cluster was successful",
+                    fg="green")
+

--- a/pf9/cluster/helpers.py
+++ b/pf9/cluster/helpers.py
@@ -1,0 +1,59 @@
+from ..exceptions import SSHInfoMissing, MissingVIPDetails
+import netifaces
+import re
+
+
+def validate_ssh_details(user, password, ssh_key):
+
+    missing = []
+    if not user:
+        missing.append('SSH user')
+    if not password and not ssh_key:
+        missing.append('SSH password or SSH key')
+
+    if missing:
+        raise SSHInfoMissing(missing)
+
+
+def get_local_node_addresses():
+    """
+    Get non local IPv4 addresses
+    """
+    nw_ifs = netifaces.interfaces()
+    nonlocal_ips = set()
+    ignore_ip_re = re.compile('^(0.0.0.0|127.0.0.1)$')
+    ignore_if_re = re.compile('^(q.*-[0-9a-fA-F]{2}|tap.*)$')
+
+    for iface in nw_ifs:
+        if ignore_if_re.match(iface):
+            continue
+        addrs = netifaces.ifaddresses(iface)
+        try:
+            if netifaces.AF_INET in addrs:
+                ips = addrs[netifaces.AF_INET]
+                for ip in ips:
+                    # Not interested in loopback IPs
+                    if not ignore_ip_re.match(ip['addr']):
+                        nonlocal_ips.add(ip['addr'])
+            else:
+                # move to next interface if this interface doesn't
+                # have IPv4 addresses
+                continue
+        except KeyError:
+            pass
+
+    return list(nonlocal_ips)
+
+
+def check_vip_needed(masters, vip, vip_if):
+    missing = []
+    if len(masters) > 1:
+        if not vip:
+            missing.append('VIP')
+        if not vip_if:
+            missing.append('VIP network interface')
+
+    if missing:
+        raise MissingVIPDetails(missing)
+
+    return True

--- a/pf9/exceptions.py
+++ b/pf9/exceptions.py
@@ -1,0 +1,44 @@
+"""
+Exceptions for Cluster Operations
+"""
+
+class CLIException(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __repr__(self):
+        return self.msg
+
+class ClusterCLIException(CLIException):
+    def __init__(self, msg):
+        self.msg = msg
+        super(ClusterCLIException, self).__init__(msg)
+
+    def __repr__(self):
+        return self.msg
+
+class SSHInfoMissing(ClusterCLIException):
+    def __init__(self, missing_fields):
+        msg = "Missing SSH details. Need following: {}".format(missing_fields)
+        super(SSHInfoMissing, self).__init__(msg)
+
+class MissingVIPDetails(ClusterCLIException):
+    def __init__(self, missing_fields):
+        msg = "VIP details needed for multimaster setups. Missing fields: {}".format(missing_fields)
+        super(MissingVIPDetails, self).__init__(msg)
+
+class ClusterCreateFailed(ClusterCLIException):
+    def __init__(self, msg):
+        super(ClusterCreateFailed, self).__init__(msg)
+
+class ClusterAttachFailed(ClusterCLIException):
+    def __init__(self, msg):
+        super(ClusterAttachFailed, self).__init__(msg)
+
+class PrepNodeFailed(ClusterCLIException):
+    def __init__(self, msg):
+        super(PrepNodeFailed, self).__init__(msg)
+
+class UserAuthFailure(CLIException):
+    def __init__(self, msg):
+        super(UserAuthFailure, self).__init__(msg)

--- a/pf9/modules/ostoken.py
+++ b/pf9/modules/ostoken.py
@@ -4,6 +4,8 @@
 # Tested with python 2.7 and 3.7.0 on OSX and Ubuntu 17.10
 # maintainer: tom.christopoulos@platform9.com
 
+from exceptions import UserAuthFailure
+import click
 import json
 import requests
 import sys
@@ -38,9 +40,10 @@ class GetToken:
                           json=body)
 
         if r.status_code not in (200, 201):
-            print("{0}: {1}".format(r.status_code, r.text))
-            sys.exit(1)
-     
+            click.echo("{0}: {1}".format(r.status_code, r.text))
+            msg = "Failed to authenticate with {}".format(host)
+            raise UserAuthFailure(msg)
+
         response = {
                 "headers": r.headers,
                 "json": r.json()

--- a/pf9/modules/ostoken.py
+++ b/pf9/modules/ostoken.py
@@ -4,7 +4,7 @@
 # Tested with python 2.7 and 3.7.0 on OSX and Ubuntu 17.10
 # maintainer: tom.christopoulos@platform9.com
 
-from exceptions import UserAuthFailure
+from ..exceptions import UserAuthFailure
 import click
 import json
 import requests

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     ],
     keywords = 'cli',
     packages = find_packages(exclude=['docs', 'tests*']),
-    install_requires = ['click', 'prettytable', 'requests', 'netifaces'],
+    install_requires = ['click', 'prettytable', 'requests', 'netifaces', 'colorama', 'click-spinner'],
     extras_require = {
         'test': ['coverage', 'pytest', 'pytest-cov', 'mock'],
     },

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     ],
     keywords = 'cli',
     packages = find_packages(exclude=['docs', 'tests*']),
-    install_requires = ['click', 'prettytable', 'requests', 'netifaces', 'colorama', 'click-spinner'],
+    install_requires = ['click', 'prettytable', 'requests', 'netifaces', 'colorama'],
     extras_require = {
         'test': ['coverage', 'pytest', 'pytest-cov', 'mock'],
     },


### PR DESCRIPTION
* Symlink to express cli as pf9ctl
* Introduced exception classes to handle error conditions all over the CLI. Makes it easier to catch, report and exit in controlled places rather than all over the code.
* Swap the behavior of bootstrap and create cluster command per product requirements. Bootstrap will create a single local node cluster only. Create command will do all possibilities.
* Cluster level helper methods are moved into their own file now.
* Added a progress bar for calling express Ansible code. These things take time and we needed to give some user feedback.
* Basic validation for user-provided inputs. But more is needed (will be a separate change)
* Handling of localhost, 127.0.01 and vice versa. Ansible needs to know it is "localhost" vs cluster attach can work only with host's IPs. So this juggling is needed.
* Dropped the verify=False flag in create cluster when we are making DU API calls. There should be no reason to skip SSL verification.
* cluster_attach was not py3 compatible. Had to move dict iteritems->items
* Added some missing pip modules. Introduced color output for success, failure which requires colorama module. 