### PR TITLE
Usability enhancements 

### DIFF
--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -36,11 +36,9 @@ def run_express(ctx, inv_file, ips):
     log_file = os.path.join("/var/log/pf9",
                             datetime.now().strftime('express_%Y_%m_%d-%H_%m_%S.log'))
     # Invoke PMK only related playbook.
-    #cmd = 'sudo {0} -a -b --pmk -v {1} -c {2} -l {3} pmk'.format(exp_ansible_runner,
-    #                                               inv_file, exp_config_file, log_file)
+    cmd = 'sudo {0} -a -b --pmk -v {1} -c {2} -l {3} pmk'.format(exp_ansible_runner,
+                                                inv_file, exp_config_file, log_file)
 
-    cmd = 'sudo {0} -a -b --pmk -v {1} -c {2} pmk'.format(exp_ansible_runner,
-                                                   inv_file, exp_config_file)
     # Current implementation is to have this express invocation dumps logs in 
     # a known location instead of capturing it here. Here we care only about
     # the exit code and fake progress.
@@ -211,7 +209,7 @@ def cluster():
 @click.argument('cluster_name')
 @click.option('--masterVip', help='IP address for VIP for master nodes', default='')
 @click.option('--masterVipIf', help='Interface name on which the VIP should bind to', default='')
-@click.option('--metallbCidr', help='IP range for MetalLB (<startIP>-<endIp>)', default='')
+@click.option('--metallbIpRange', help='IP range for MetalLB (<startIP>-<endIp>)', default='')
 @click.option('--containersCidr', type=str, required=False, default='10.20.0.0/16', help="CIDR for container overlay")
 @click.option('--servicesCidr', type=str, required=False, default='10.21.0.0/16', help="CIDR for services overlay")
 @click.option('--externalDnsName', type=str, required=False, default='', help="External DNS name for master VIP")
@@ -222,8 +220,8 @@ def cluster():
 @click.option('--user', '-u', help='Username for node.')
 @click.option('--password', '-p', help='Password for node if different than cluster default.')
 @click.option('--ssh-key', '-s', help='SSH key for node if different than cluster default.')
-@click.option('--master-ip', '-m', multiple=True, help='IPs of the master nodes.', required=True)
-@click.option('--worker-ip', '-w', multiple=True, help='IPs of the worker nodes.', default='')
+@click.option('--master-ip', '-m', multiple=True, help='IPs of the master nodes. Specify multiple IPs by repeating this option.', required=True)
+@click.option('--worker-ip', '-w', multiple=True, help='IPs of the worker nodes. Specify multiple IPs by repeating this option.', default='')
 @click.pass_context
 def create(ctx, **kwargs):
     """Create a Kubernetes cluster"""
@@ -359,8 +357,8 @@ def bootstrap(ctx, **kwargs):
 
 @cluster.command('attach-node')
 @click.argument('cluster_name')
-@click.option('--master-ip', '-m', multiple=True, help='IP of the node to be added as masters')
-@click.option('--worker-ip', '-w', multiple=True, help='IP of the node to be added as workers')
+@click.option('--master-ip', '-m', multiple=True, help='IP of the node to be added as masters, Specify multiple IPs by repeating this option.')
+@click.option('--worker-ip', '-w', multiple=True, help='IP of the node to be added as workers. Specify multiple IPs by repeating this option.')
 @click.pass_context
 def attach_node(ctx, **kwargs):
     """
@@ -397,7 +395,7 @@ def attach_node(ctx, **kwargs):
 @click.option('--user', '-u', help='SSH username for nodes.')
 @click.option('--password', '-p', help='SSH password for nodes.')
 @click.option('--ssh-key', '-s', help='SSH key for nodes.')
-@click.option('--ips', '-i', multiple=True, help='IPs of the host to be prepped.')
+@click.option('--ips', '-i', multiple=True, help='IPs of the host to be prepped. Specify multiple IPs by repeating this option.')
 @click.pass_context
 def prepnode(ctx, user, password, ssh_key, ips):
     """ 
@@ -407,7 +405,7 @@ def prepnode(ctx, user, password, ssh_key, ips):
         prompt_msg = "No IPs provided. Proceed with preparing the current node to be added to a Kubernetes cluster [y/n]?"
 
         localnode_confirm = click.prompt(prompt_msg, default = 'y')
-        if prompt_msg.lower() == 'n':
+        if localnode_confirm.lower() == 'n':
             sys.exit(1)
         else:
             ips = ("localhost",)

--- a/pf9/config/commands.py
+++ b/pf9/config/commands.py
@@ -8,7 +8,7 @@ from ..modules.util import GetConfig
 
 @click.group()
 def config():
-    """Configure Platform9 Express."""
+    """Configure CLI for Platform9 management planes."""
 def manage_dns_resolvers(ctx, param, value):
     if value:
         if ctx.params['dns_resolver1'] is None:
@@ -35,7 +35,7 @@ def manage_dns_resolvers(ctx, param, value):
 @click.option('--manage_resolver', type=bool, default=False, callback=manage_dns_resolvers)
 @click.pass_context
 def create(ctx, **kwargs):
-    """Create Platform9 Express config."""
+    """Create Platform9 management plane config."""
     # creates and activates pf9-express config file
 
     pf9_exp_conf_dir = ctx.obj['pf9_exp_conf_dir']
@@ -65,13 +65,13 @@ def create(ctx, **kwargs):
     with open(pf9_exp_conf_dir + 'express.conf', 'w') as file:
         for k,v in ctx.params.items():
             file.write(k + '|' + str(v) + '\n')
-    click.echo('Successfully wrote Platform9 Express configuration')
+    click.echo('Successfully wrote Platform9 management plane configuration')
 
 
 @config.command('list')
 @click.pass_obj
 def list(obj):
-    """List Platform9 Express configs."""
+    """List Platform9 management plane configs."""
     # lists pf9-express config files
     pf9_exp_conf_dir = obj['pf9_exp_conf_dir']
 
@@ -96,14 +96,14 @@ def list(obj):
         click.echo(result)
 
     else:
-        click.echo('No Platform9 Express configs exist')
+        click.echo('No Platform9 management plane configs exist')
 
 
 @config.command('activate')
 @click.argument('config')
 @click.pass_obj
 def activate(obj, config):
-    """Activate Platform9 Express config."""
+    """Activate Platform9 management plane config."""
     # activates pf9-express config file
     click.echo("Activating config %s" % config)
     dir_path = obj['pf9_exp_conf_dir']
@@ -132,7 +132,7 @@ def activate(obj, config):
 @config.command('validate')
 @click.pass_context
 def config_validate(ctx, **kwargs):
-    """Validate Active Platform9 Express config."""
+    """Validate active Platform9 management plane config."""
     # Validates pf9-express config file and obtains Auth Token
     #Load Active Config into ctx
     GetConfig(ctx).GetActiveConfig()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,7 +109,7 @@ class TestConfigCreateFull(TestCase):
                     '--dns_resolver2=2.2.2.2'], 
                 obj=self.obj_test)
         assert (result.exit_code == 0)
-        assert ('Successfully wrote Platform9 Express configuration' in result.output)
+        assert ('Successfully wrote Platform9 management plane configuration' in result.output)
 # !!! Need to compaire elements of both config files
 # !!! They are strings so either readline and evaluate each against other file or split('\n', list).sort()
 #        with open(os.path.join(self.conf_dir, 'express.conf'), 'r') as read_test_conf:
@@ -161,7 +161,7 @@ class TestConfigCreateMinimal(TestCase):
                     '--os_tenant=service'], 
                 obj=self.obj_test)
         assert (result.exit_code == 0)
-        assert ('Successfully wrote Platform9 Express configuration' in result.output)
+        assert ('Successfully wrote Platform9 management plane configuration' in result.output)
 # !!! Need to compaire elements of both config files
 
 
@@ -195,14 +195,14 @@ class TestConfigList(TestCase):
         runner = CliRunner()
         result = runner.invoke(cli_config_list, obj=self.obj_test)
         assert (result.exit_code == 0)
-        assert ('No Platform9 Express configs exist' in result.output)
+        assert ('No Platform9 management plane configs exist' in result.output)
 
     def test_config_list_empty(self):
         os.makedirs(self.conf_dir, 0o755)
         runner = CliRunner()
         result = runner.invoke(cli_config_list, obj=self.obj_test)
         assert result.exit_code == 0
-        assert ('No Platform9 Express configs exist' in result.output or 'Management Plane' in result.output)
+        assert ('No Platform9 management plane configs exist' in result.output or 'Management Plane' in result.output)
 
     def test_config_list_with_config(self):
         os.makedirs(self.conf_dir, 0o755)


### PR DESCRIPTION
* Route logs from the express to a known dir path
* Make the help text better for several commands based on feedback from users.
* prep-node would ignore user's response to not proceed with the command when prompted. This is now addressed.
* Remove references to "express" in help text.