### PR TITLE
Get rid of extra get_local_node_addresses and its usage

### DIFF
--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -425,7 +425,7 @@ def prepnode(ctx, user, password, ssh_key, ips):
     try:
         for ip in parse_ips:
             if ip == "127.0.0.1" or ip == "localhost" \
-                or ip in Utils().get_local_node_addresses():
+                or ip in get_local_node_addresses():
                 adj_ips = adj_ips + ("localhost",)
             else:
                 # check if ssh creds are provided.

--- a/pf9/modules/util.py
+++ b/pf9/modules/util.py
@@ -68,36 +68,6 @@ class Utils:
                 config.update( {'manage_resolver' : line.replace('manage_resolver|','')} )
         return config
 
-    def get_local_node_addresses(self):
-        """
-        Get non local IPv4 addresses
-        """
-        nw_ifs = netifaces.interfaces()
-        nonlocal_ips = set()
-        ignore_ip_re = re.compile('^(0.0.0.0|127.0.0.1)$')
-        ignore_if_re = re.compile('^(q.*-[0-9a-fA-F]{2}|tap.*)$')
-
-        for iface in nw_ifs:
-            if ignore_if_re.match(iface):
-                continue
-            addrs = netifaces.ifaddresses(iface)
-            try:
-                if netifaces.AF_INET in addrs:
-                    ips = addrs[netifaces.AF_INET]
-                    for ip in ips:
-                        # Not interested in loopback IPs
-                        if not ignore_ip_re.match(ip['addr']):
-                            nonlocal_ips.add(ip['addr'])
-                else:
-                    # move to next interface if this interface doesn't
-                    # have IPv4 addresses
-                    continue
-            except KeyError:
-                pass
-
-        return list(nonlocal_ips)
-
-
 
 class Pf9ExpVersion:
     ''' Methods for managing PF9 Versions'''


### PR DESCRIPTION
This method is now present in helpers.py. Remove the method and all references
to it.