### PR TITLE
Adds conditional to credential prompts to facilitate running non-interactively

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -177,13 +177,19 @@ setup_venv() {
 }
 
 prompt_account_inputs() {
-    read -p "Platform9 account management URL [Example: https://example.platform9.io]: " MGMTURL
+    if [[ ! ${MGMTURL} ]]; then
+        read -p "Platform9 account management URL [Example: https://example.platform9.io]: " MGMTURL
+    fi
     if [[ ${MGMTURL} != https://* ]]; then
         MGMTURL=https://${MGMTURL}
         write_out_log "Platform9 account management URL should start with https://. Trying with ${MGMTURL}"
     fi
-    read -p "Platform9 username: " USER
-    read -sp "Platform9 user password: " PASS
+    if [[ ! ${USER} ]]; then
+        read -p "Platform9 username: " USER
+    fi
+    if [[ ! ${PASS} ]]; then
+        read -sp "Platform9 user password: " PASS
+    fi
     echo
     # Assume defaults for the region/project unless we get it from the env
     if [ -z "${PF9_PROJECT}" ]; then


### PR DESCRIPTION
This change only checks for the existence of the `MGMTURL`, `USER`, and `PASS` variables before prompting for them.

I believe this change is helpful for use with host provisioning and configuration management tools (i.e. in my use of managed PMK with Terraform), rather than handling responses to the prompts in situations like these. 