### PR TITLE
Set monitoring tags by default

### DIFF
--- a/pf9/cluster/cluster_create.py
+++ b/pf9/cluster/cluster_create.py
@@ -64,7 +64,7 @@ class CreateCluster(object):
             "appCatalogEnabled": self.ctx.params['appcatalogenabled'],
             "allowWorkloadsOnMaster": self.ctx.params['allowworkloadsonmaster'],
             "masterless": False,
-            "tags": {},
+            "tags": {"pf9-system:monitoring": "true"}, # opt-out monitoring
             "runtimeConfig": "",
             "nodePoolUuid": nodepool_id,
             "masterVipIpv4": self.ctx.params['mastervip'],


### PR DESCRIPTION
This change pushes tags which enable prometheus on PMK clusters by default.
The idea is to have cluster level prometheus collect metrics and push them to ops cortex by default.
Same mechanism is being built with UI.

* ran unit tests
* patched library on a master node, created cluster with cli and verified that tags are set.