### PR TITLE
Tomchris/support bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm 
+.idea/

--- a/pf9/exceptions.py
+++ b/pf9/exceptions.py
@@ -2,12 +2,20 @@
 Exceptions for Cluster Operations
 """
 
+
 class CLIException(Exception):
     def __init__(self, msg):
+        super(CLIException, self).__init__(msg)
         self.msg = msg
 
     def __repr__(self):
         return self.msg
+
+
+class DUCommFailure(CLIException):
+    def __init__(self, msg):
+        super(DUCommFailure, self).__init__(msg)
+
 
 class ClusterCLIException(CLIException):
     def __init__(self, msg):
@@ -17,31 +25,38 @@ class ClusterCLIException(CLIException):
     def __repr__(self):
         return self.msg
 
+
 class SSHInfoMissing(ClusterCLIException):
     def __init__(self, missing_fields):
         msg = "Missing SSH details. Need following: {}".format(missing_fields)
         super(SSHInfoMissing, self).__init__(msg)
+
 
 class MissingVIPDetails(ClusterCLIException):
     def __init__(self, missing_fields):
         msg = "VIP details needed for multimaster setups. Missing fields: {}".format(missing_fields)
         super(MissingVIPDetails, self).__init__(msg)
 
+
 class ClusterCreateFailed(ClusterCLIException):
     def __init__(self, msg):
         super(ClusterCreateFailed, self).__init__(msg)
+
 
 class ClusterAttachFailed(ClusterCLIException):
     def __init__(self, msg):
         super(ClusterAttachFailed, self).__init__(msg)
 
+
 class FailedActiveMasters(ClusterCLIException):
     def __init__(self, msg):
         super(FailedActiveMasters, self).__init__(msg)
 
+
 class PrepNodeFailed(ClusterCLIException):
     def __init__(self, msg):
         super(PrepNodeFailed, self).__init__(msg)
+
 
 class UserAuthFailure(CLIException):
     def __init__(self, msg):

--- a/pf9/express.py
+++ b/pf9/express.py
@@ -9,7 +9,8 @@ from os.path import expanduser
 from .modules.util import Pf9ExpVersion
 
 from .config.commands import config
-from .cli.commands import version 
+from .support.commands import support
+from .cli.commands import version
 from .cluster.commands import cluster 
 
 @click.group()
@@ -29,8 +30,10 @@ def cli(ctx):
     ctx.obj['pf9_exp_ansible_runner'] = os.path.join(ctx.obj['pf9_exp_dir'],
                                                      'express', 'pf9-express')
 
+
 cli.add_command(version)
 cli.add_command(config)
+cli.add_command(support)
 cli.add_command(cluster)
 
 

--- a/pf9/modules/express.py
+++ b/pf9/modules/express.py
@@ -1,0 +1,181 @@
+"""
+Module for driving Platform9's Express project from python.
+Express is a tool for leveraging Ansible to bring hosts \
+        under management of a Platform9 management plane.
+Express can be found @ https://github.com/platform9/express.git
+"""
+
+import os
+from ..exceptions import CLIException
+from ..exceptions import UserAuthFailure
+#from .ostoken import GetRegionURL
+from .ostoken import GetToken
+
+
+class ResMgr:
+    """express.ResMgr(ctx) contains methods to interact with Platform9 Reservation Manager"""
+    def __init__(self, region_url, token):
+        self.region_url = region_url 
+        self.token = token
+
+    def get_hosts(self):
+        """express.ResMgr().get_resmgr_hosts
+        Calls Platform9 Reservation Manager using active config
+        retrieves all hosts associated with the region. (Responding, Not Responding, Not Authorized)
+                return resmgr_hosts_json
+        """
+        return_msg = ("--- Not Implemented ---"
+              "Move just  call from support bundle here")
+        print(return_msg)
+        return return_msg
+        # resmgr_bundle_resp = requests.post("{}{}/support/bundle".
+        #                                   format(_resmgr_endpoint,
+        #                                          host_values['id']
+        #                                          ), verify=False, headers=headers)
+
+    def request_support_bundle(self,host_id):
+        """express.ResMgr().request_support_bundle(host_id)"""
+        return_msg = ("--- Not Implemented ---"
+                      "Move call from support bundle create"
+                      "takes in ")
+        print(return_msg)
+        return return_msg
+
+
+class Get:
+    """Express.Get(ctx) contains method to "GET" data required to run express"""
+    def __init__(self, ctx):
+        self.ctx = ctx
+        
+    def get_token_project(self):
+        """Calls ostoken.GetToken().get_token_project() using active config
+                return token, project_id
+        """
+        try:
+            self.active_config()
+            token_project = GetToken().get_token_project(
+                self.ctx.params["du_url"],
+                self.ctx.params["du_username"],
+                self.ctx.params["du_password"],
+                self.ctx.params["du_tenant"])
+            if not token_project:
+                except_err = "Failed to obtain an Authentication Token from: {}".format(self.ctx.params["du_url"])
+                raise CLIException(except_err)
+            return token_project
+        except UserAuthFailure:
+            raise
+        except CLIException as except_err:
+            raise except_err
+        
+    def get_token(self):
+        """Calls ostoken.GetToken.get_token_v3 using active config
+                return token
+        """
+        try:
+            self.active_config()
+            token = GetToken().get_token_v3(
+                self.ctx.params["du_url"],
+                self.ctx.params["du_username"],
+                self.ctx.params["du_password"],
+                self.ctx.params["du_tenant"])
+            if not token:
+                except_err = "Failed to obtain an Authentication Token from: {}".format(self.ctx.params["du_url"])
+                raise CLIException(except_err)
+            return token
+        except UserAuthFailure:
+            raise
+        except CLIException as except_err:
+            raise except_err
+
+#   def region_fqdn(self):
+#       """Calls ostoken.GetRegionURL().get_region_url.
+#               return region_fqdn
+#       """
+
+#       try:
+#           self.active_config()
+#           region_url = GetRegionURL(
+#               self.ctx.params["du_url"],
+#               self.ctx.params["du_username"],
+#               self.ctx.params["du_password"],
+#               self.ctx.params["du_tenant"],
+#               self.ctx.params["du_region"]).get_region_url()
+#           if region_url is None:
+#               msg = "Failed to obtain region url from: {} " \
+#                     "for region: {}".format(self.ctx.param["du_url"], self.ctx.param["du_region"])
+#               raise CLIException(msg)
+#           return region_url
+#       except CLIException:
+#           raise
+
+    def active_config(self):
+        """Load Active config into ctx
+            return
+                   ctx.params['du_url']
+                   ctx.params['du_username']
+                   ctx.params['du_password']
+                   ctx.params['du_tenant']
+                   ctx.params['du_region']
+            return does not need to be captured if context is available
+        """
+        config_file = os.path.join(self.ctx.obj['pf9_exp_conf_dir'], 'express.conf')
+        if os.path.exists(config_file):
+            try:
+                with open(config_file, 'r') as data:
+                    config_file_lines = data.readlines()
+            except Exception:
+                msg = "Failed reading {}: ".format(config_file)
+                raise CLIException(msg)
+
+            config = self.config_to_dict(config_file_lines)
+            if config is not None:
+                self.ctx.params['du_url'] = config["du_url"]
+                self.ctx.params['du_username'] = config["os_username"]
+                self.ctx.params['du_password'] = config["os_password"]
+                self.ctx.params['du_tenant'] = config["os_tenant"]
+                self.ctx.params['du_region'] = config["os_region"]
+            return self.ctx
+        msg = "No active config. Please define or activate a config."
+        raise CLIException(msg)
+
+    @staticmethod
+    def config_to_dict(config_file):
+        """Convert Pipe separated config to Dict()
+                return config
+        """
+        config = {}
+        for line in config_file:
+            if 'config_name|' in line:
+                line = line.strip()
+                config.update({'name': line.replace('config_name|', '')})
+            if 'du_url' in line:
+                line = line.strip()
+                config.update({'du_url': line.replace('du_url|', '')})
+            if 'os_tenant' in line:
+                line = line.strip()
+                config.update({'os_tenant': line.replace('os_tenant|', '')})
+            if 'os_username' in line:
+                line = line.strip()
+                config.update({'os_username': line.replace('os_username|', '')})
+            if 'os_region' in line:
+                line = line.strip()
+                config.update({'os_region': line.replace('os_region|', '')})
+            if 'os_password' in line:
+                line = line.strip()
+                config.update({'os_password': line.replace('os_password|', '')})
+            if 'proxy_url' in line:
+                line = line.strip()
+                config.update({'proxy_url': line.replace('proxy_url|', '')})
+            if 'dns_resolver1' in line:
+                line = line.strip()
+                config.update({'dns_resolver1': line.replace('dns_resolver1|', '')})
+            if 'dns_resolver_2' in line:
+                line = line.strip()
+                config.update({'dns_resolver_2': line.replace('dns_resolver_2|', '')})
+            if 'manage_hostname' in line:
+                line = line.strip()
+                config.update({'manage_hostname': line.replace('manage_hostname|', '')})
+            if 'manage_resolver' in line:
+                line = line.strip()
+                config.update({'manage_resolver': line.replace('manage_resolver|', '')})
+        return config

--- a/pf9/modules/util.py
+++ b/pf9/modules/util.py
@@ -4,6 +4,8 @@ import re
 import requests
 import os
 import click
+import socket
+
 
 class GetConfig(object):
     def __init__(self, ctx):
@@ -30,6 +32,11 @@ class GetConfig(object):
 
 
 class Utils:
+    """Resolve IP of an FQDN and return IP as a string"""
+    @staticmethod
+    def ip_from_dns_name(fqdn):
+        return str(socket.gethostbyname_ex(fqdn)[2][0])
+
     def config_to_dict(self, config_file):
         config = {}
         for line in config_file:

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -29,9 +29,9 @@ def bundle():
 
 @bundle.command('')
 @click.option('--host', help='Host for which you want a support bundle generated')
-@click.option('--silent', '-s', is_flag=True, help='Run silently, Helpful when utilized in scripts.')
-@click.option('--mgmt-plane', '-m', is_flag=True, help='Direct to host request to generate a support bundle.')
-@click.option('--offline', '-o', is_flag=True, help='Direct to host request to generate a support bundle.')
+@click.option('--silent', '-s', is_flag=True, hidden=True, help='Run silently, Helpful when utilized in scripts.')
+@click.option('--mgmt-plane', '-m', is_flag=True, hidden=True, help='Direct to host request to generate a support bundle.')
+@click.option('--offline', '-o', is_flag=True, hidden=True, help='Direct to host request to generate a support bundle.')
 @click.pass_context
 def create(ctx, silent, host, offline, mgmt_plane):
     """Request Creation of a Platform9 Support"""
@@ -102,7 +102,7 @@ def create(ctx, silent, host, offline, mgmt_plane):
                 else:
                     password = getpass.unix_getpass()
                     ssh_auth = {"look_for_keys": "false", "password": password}
-                click.echo("Sudo password for host: " + host)
+                click.echo("Sudo ", nl=False)
                 sudo_pass = getpass.unix_getpass()
                 config = Config(overrides={'sudo': {'password': sudo_pass}})
                 ssh_conn = Connection(host=host,

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -1,0 +1,128 @@
+"""CLI Support Commands """
+import sys
+import click
+import requests
+import urllib3
+from ..exceptions import DUCommFailure
+from ..exceptions import CLIException
+from ..modules.express import Get
+from ..modules.util import Utils
+import ipaddress
+
+
+@click.group()
+def support():
+    """Platform9 Support Utilities"""
+
+
+@support.group()
+def bundle():
+    """Manage Platform9 Support Bundles"""
+
+
+@bundle.command('')
+@click.option('--host', help='Host for which you want a support bundle generated')
+@click.option('--silent', '-s', is_flag=True, help='Run silently, Helpful when utilized in scripts.')
+@click.option('--off-line', '-o', is_flag=True, help='Direct to host request to generate a support bundle.')
+@click.pass_context
+def create(ctx, silent, host, off_line):
+    """Request Creation of a Platform9 Support"""
+
+    if off_line:
+        if not host or host in ['localhost', '127.0.0.1']:
+            use_localhost = click.prompt("Use localhost? [y/n]", default='y')
+            if use_localhost.lower() == 'n':
+                click.echo("Quiting...")
+                sys.exit(1)
+            host = "127.0.0.1"
+
+        click.echo("Directly requesting support bundle generation from \n"
+                   "host: {}".format(host))
+
+    if not host:
+        except_msg = "No host provided."
+        # -- NOT IMPLEMENTED --
+        # Need to generate a list of hosts from resmgr/local inventories
+        #raise CLIException(except_msg)
+        click.echo("\n" + except_msg)
+        click.echo("\n\n" + click.Context(create).get_help())
+        sys.exit(1)
+
+    # \/--- From-Here ---\/
+    # This all needs to go into a Module
+    try:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+        token, project_id = Get(ctx).get_token_project()
+    except CLIException as except_err:
+        click.echo(except_err)
+        sys.exit(1)
+    # Building the data set
+    _resmgr_endpoint = '{}/resmgr/v1/hosts/'.format(ctx.params['du_url'])
+    headers = {'Content-Type': 'application/json', 'X-Auth-Token': token}
+    try:
+        ipaddress.ip_address(host)
+    except ipaddress.AddressValueError:
+        pass
+        host = Utils.ip_from_dns_name(host)
+        # Need to handle hostname lookup against resmgr as well
+        # Need to move this into a loop to validate again and fail if resolve doesn't work
+        # except_msg = "Host provided could not be resolved to an IP address"
+        #    raise CLIException(except_msg)
+
+    try:
+        resmgr_get_hosts = requests.get(_resmgr_endpoint,
+                                        verify=False,
+                                        headers=headers)
+        if resmgr_get_hosts.status_code not in (200, 201):
+            except_msg = "Failed to obtain host data from Platform9 Management Plane Reservation Manger"
+            raise DUCommFailure(except_msg)
+
+        host_values = {}
+        for host_data in resmgr_get_hosts.json():
+            if 'responding' in host_data['info'] and host_data['info']['responding']:
+                if host in host_data['extensions']['ip_address']['data']:
+                    host_values['hostname'] = host_data['info']['hostname']
+                    host_values['id'] = host_data['id']
+                    host_values['ip_addresses'] = host_data['extensions']['ip_address']['data']
+    except (DUCommFailure, CLIException) as except_err:
+        click.echo(except_err)
+        sys.exit(1)
+
+    if len(host_values):
+        resmgr_bundle_resp = requests.post("{}{}/support/bundle".
+                                           format(_resmgr_endpoint,
+                                                  host_values['id']
+                                                  ), verify=False, headers=headers)
+        if resmgr_bundle_resp.status_code not in (200, 201):
+            except_msg = "Failure: Request to the Platform9 Management Plane for support bundle generation failed:" \
+                         "host: {}\n" \
+                         "hostname: {}\n" \
+                         "id: {}\n" \
+                         "response status_code: {}".format(
+                          host, host_values['hostname'],
+                          host_values['id'],
+                          resmgr_bundle_resp.status_code)
+            raise DUCommFailure(except_msg)
+        # /\--- To-Here ---/\
+
+        click.echo("Request to generate a support bundle succeeded:"
+                   "    host: {}\n"
+                   "    hostname: {}\n"
+                   "    id: {}\n"
+                   "    response status_code: {}".format(
+                    host, host_values['hostname'],
+                    host_values['id'], resmgr_bundle_resp.status_code))
+        sys.exit(0)
+    else:
+        click.echo("Unable to find an Active node that matched host: {}".format(host))
+        sys.exit(1)
+
+    if not silent:
+        click.echo("")
+
+
+@bundle.command('list')
+@click.pass_obj
+def list_bundles(obj):
+    """List all available Platform9 Support"""
+    click.echo("List all support bundles") 

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -63,8 +63,7 @@ def create(ctx, silent, host, offline, mgmt_plane):
                 click.echo(out)
                 return 0, out
             except subprocess.CalledProcessError as except_err:
-                click.echo("Support Bundle Creation Failed: " + except_err)
-                # return e.returncode, e.output
+                click.echo("Support Bundle Creation Failed:")
 
         click.echo("Requesting support bundle generation directly from host: {}".format(host))
         ssh_dir = os.path.join(os.path.expanduser("~"), '.ssh/')

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -59,9 +59,19 @@ def create(ctx, silent, host, offline, mgmt_plane):
     if offline:
         if use_localhost:
             try:
-                out = subprocess.check_output(shlex.split(bundle_exec))
-                click.echo(out)
-                return 0, out
+                click.echo("Generating support bundle on localhost")
+                subprocess.run(shlex.split('sudo ' + bundle_exec))
+                check_bundle_out = subprocess.run(["sudo", "ls", "-sh", "/tmp/pf9-support.tgz"],
+                                                  stdout=subprocess.PIPE,
+                                                  stderr=subprocess.PIPE)
+                if check_bundle_out.returncode == 0:
+                    click.echo("Generation of support bundle complete on:\n"
+                               "Host: localhost")
+                    click.echo(check_bundle_out.stdout)
+                    exit(0)
+                else:
+                    click.echo("Support Bundle Creation Failed:")
+                    exit(1)
             except subprocess.CalledProcessError as except_err:
                 click.echo("Support Bundle Creation Failed:")
                 exit(1)

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -64,6 +64,7 @@ def create(ctx, silent, host, offline, mgmt_plane):
                 return 0, out
             except subprocess.CalledProcessError as except_err:
                 click.echo("Support Bundle Creation Failed:")
+                exit(1)
 
         click.echo("Requesting support bundle generation directly from host: {}".format(host))
         ssh_dir = os.path.join(os.path.expanduser("~"), '.ssh/')

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -60,14 +60,12 @@ def create(ctx, silent, host, offline, mgmt_plane):
         if use_localhost:
             try:
                 click.echo("Generating support bundle on localhost")
-                subprocess.run(shlex.split('sudo ' + bundle_exec))
-                check_bundle_out = subprocess.run(["sudo", "ls", "-sh", "/tmp/pf9-support.tgz"],
-                                                  stdout=subprocess.PIPE,
-                                                  stderr=subprocess.PIPE)
-                if check_bundle_out.returncode == 0:
+                subprocess.check_output(shlex.split("sudo " + bundle_exec))
+                check_bundle_out = subprocess.check_output(shlex.split("sudo ls -sh /tmp/pf9-support.tgz"))
+                if check_bundle_out:
                     click.echo("Generation of support bundle complete on:\n"
                                "Host: localhost")
-                    click.echo(check_bundle_out.stdout)
+                    click.echo(check_bundle_out)
                     exit(0)
                 else:
                     click.echo("Support Bundle Creation Failed:")
@@ -77,7 +75,7 @@ def create(ctx, silent, host, offline, mgmt_plane):
                 exit(1)
 
         click.echo("Requesting support bundle generation directly from host: {}".format(host))
-        ssh_dir = os.path.join(os.path.expanduser("~"), '.ssh/')
+        ssh_dir = os.path.join(os.path.expanduser("~"), '.ssh/id_rsa')
         user_name = getpass.getuser()
         ssh_conn = Connection(host=host,
                               user=user_name,

--- a/setup.py
+++ b/setup.py
@@ -27,16 +27,16 @@ class RunTests(Command):
 
 
 setup(
-    name = 'express-cli',
-    version = __version__,
-    description = 'Express CLI.',
-    long_description = open('README.md').read(),
-    long_description_content_type = 'text/markdown',
-    url = 'https://github.com/platform9/express-cli',
-    author = 'Jeremy Brooks',
-    author_email = 'jeremy@platform9.com',
-    license = 'Apache 2.0',
-    classifiers = [
+    name='express-cli',
+    version=__version__,
+    description='Express CLI.',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/platform9/express-cli',
+    author='Jeremy Brooks',
+    author_email='jeremy@platform9.com',
+    license='Apache 2.0',
+    classifiers=[
         'Intended Audience :: System Administrators',
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Developers',
@@ -52,21 +52,30 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
-    package_data = {
+    package_data={
         'pf9':['templates/*',],
     },
     include_package_data=True,
     zip_safe=False,
-    keywords = 'cli',
-    packages = find_packages(exclude=['docs', 'tests*']),
-    install_requires = ['click', 'prettytable', 'requests', 'netifaces', 'colorama'],
-    extras_require = {
+    keywords='cli',
+    packages=find_packages(exclude=['docs', 'tests*']),
+    install_requires=['click',
+                      'prettytable',
+                      'requests',
+                      'netifaces',
+                      'colorama',
+                      'urllib3',
+                      'paramiko',
+                      'fabric',
+                      'invoke'
+                      ],
+    extras_require={
         'test': ['coverage', 'pytest', 'pytest-cov', 'mock'],
     },
-    entry_points = {
+    entry_points={
         'console_scripts': [
             'express=pf9.express:cli',
         ],
     },
-    cmdclass = {'test': RunTests},
+    cmdclass={'test': RunTests},
 )


### PR DESCRIPTION
Added `support bundle create` to express-cli
Can trigger a request to build a support bundle via Resmgr or Directly to a host.
Defaults to calling directly to a host (or localhost). 
Calls `/opt/pf9/hostagent/lib/python2.7/site-packages/datagatherer/datagatherer.py` to generate the support bundle. 