### PR TITLE
pin openstacksdk to py3.5 compatible version

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -55,7 +55,7 @@ install_pip_prereqs() {
 
         ## install additional pip-based packages
         write_out_log "Installing dependencies from pypi in ${cli_setup_dir}"
-        for pkg in openstacksdk; do
+        for pkg in 'openstacksdk<=0.43.0'; do
             sudo ${cli_setup_dir}/bin/pip install ${pkg} --ignore-installed >> ${log} 2>&1
             if [ $? -ne 0 ]; then
             echo -e "\nERROR: failed to install ${pkg} - here's the last 10 lines of the log:\n"


### PR DESCRIPTION
a basic ubuntu16 image ships with python3.5. the newest openstacksdk package (0.44.0, released this morning) depends on the futurist package, which is not compatible with python3.5. so, we should pin openstacksdk<=0.43.0 to maintain compatibility