### PR TITLE
Fix typo in region override option

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -271,7 +271,7 @@ while [ $# -gt 0 ]; do
     shift
     ;;
     --pf9_region)
-        REGION=${2}
+        PF9_REGION=${2}
     shift
     ;;
     --pf9_project)


### PR DESCRIPTION
The wrong variable was getting set when parsing the command line to override the
region parameter when setting up the CLI.