### PR TITLE
Add sshpass to prereq packages

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -315,7 +315,7 @@ install_prereqs() {
                 tail -10 ${log_file}; exit 1
         fi
 
-        for pkg in haveged; do
+        for pkg in haveged sshpass; do
             dpkg-query -f '${binary:Package}\n' -W | grep ^${pkg}$ > /dev/null 2>&1
             if [ $? -ne 0 ]; then
                 sudo apt-get -y install ${pkg} >> ${log_file} 2>&1
@@ -335,7 +335,7 @@ install_prereqs() {
         fi
     elif [[ "$ID" == "centos" ]]; then
         sudo rpm -Uvh https://download.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-        for pkg in git haveged; do
+        for pkg in git haveged sshpass; do
             sudo yum install -y ${pkg} >> ${log_file} 2>&1
             if [ $? -ne 0 ]; then
                 echo -e "\nERROR: failed to install ${pkg} - here's the last 10 lines of the log:\n"


### PR DESCRIPTION
This is required by ansible to prep remote node

Testing:
Tested installing sshpass on U16, U18 and Centos7.7