### PR TITLE
Don't upgrade all packages on Ubuntu

### DIFF
--- a/pf9/express/roles/common/tasks/ubuntu.yml
+++ b/pf9/express/roles/common/tasks/ubuntu.yml
@@ -6,11 +6,6 @@
     force_apt_get: yes
     cache_valid_time: 3600
 
-- name: Upgrade System Packages
-  apt:
-    upgrade: dist
-    force_apt_get: yes
-
 - name: Install curl, uuid-runtime, software-properties-common, logrotate
   apt:
     pkg:


### PR DESCRIPTION
This may be unexpected for customers to upgrade ALL packages on the box. Also
this can take an unusually long time.