### PR TITLE
Add warning message for non UTF-8 locale

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -302,6 +302,11 @@ validate_platform() {
      stdout_log "Unsupported Linux distribution"
      exit 99
   fi
+
+  # check for locale
+  if [[ "${LANG}" != "en_US.UTF-8" ]]; then
+    stdout_log "Warning: Expected locale en_US.UTF-8 but found ${LANG}. CLI Installation may fail"
+  fi
 }
 
 install_prereqs() {

--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -304,8 +304,8 @@ validate_platform() {
   fi
 
   # check for locale
-  if [[ "${LANG}" != "en_US.UTF-8" ]]; then
-    stdout_log "Warning: Expected locale en_US.UTF-8 but found ${LANG}. CLI Installation may fail"
+  if [[ "${LANG}" != *"UTF-8"* ]]; then
+    stdout_log "Warning: Expected unicode supported locale like en_US.UTF-8 but found ${LANG}. CLI Installation may fail"
   fi
 }
 


### PR DESCRIPTION
Issue: https://github.com/platform9/express-cli/issues/76

We do not want to fail the install altogether because there are
different ways to specify the locale string. This is a best effort
fix to warn the user about possible failure.
As long as the system locale isn't purely ASCII based, the CLI will work.