### PR TITLE
Instrumentation of CLI cluster commands

### DIFF
--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -348,7 +348,7 @@ def bootstrap(ctx, **kwargs):
                                     arg_floating_ip=ctx.params.get('floating_ip', None),
                                     keystone_user_id=ctx.params['user_id'],
                                     du_account_url=ctx.params['du_url'])
-    SegmentSessionWrapper(ctx).load_segment_session(segment_session, segment_event_properties, "Bootstrap")
+    SegmentSessionWrapper(ctx).load_segment_session(segment_session, segment_event_properties, "Bootstrap Cluster")
     SegmentSessionWrapper(ctx).send_track("Load Active config")
     segment_session.send_identify(ctx.params['du_username'], ctx.params['user_id'])
 
@@ -445,6 +445,7 @@ def attach_node(ctx, **kwargs):
     # handles this situation
     try:
         attach_cluster(ctx.params['cluster_name'], master_ips, worker_ips, ctx)
+        SegmentSessionWrapper(ctx).send_track("Attach Cluster Complete")
     except CLIException as e:
         logger.exception("Cluster Attach Failed")
         click.secho("Encountered an error while attaching nodes to a Kubernetes"\

--- a/pf9/modules/analytics_utils.py
+++ b/pf9/modules/analytics_utils.py
@@ -1,0 +1,102 @@
+import analytics
+import uuid
+import math
+import time
+import datetime
+import os
+from pf9.modules.util import Utils, Logger
+
+logger = Logger(os.path.join(os.path.expanduser("~"), 'pf9/log/pf9ctl.log')).get_logger(__name__)
+
+# the write_key is the Segment API authorization and identifier, without this no data submission will work. The API Key below is for Dev/Test work
+analytics.write_key = 'qDQpEaZQnDgqpXXG6jiV7OlZGqYZlQAa'
+
+
+class SegmentSessionWrapper:
+    def __init__(self, ctx):
+        self.ctx = ctx
+
+    def load_segment_session(self, segment_session, segment_event_properties, segment_subcommand):
+        """Load segment session related objects to ctx
+        """
+        self.ctx.params["segment_session"] = segment_session
+        self.ctx.params["segment_event_properties"] = segment_event_properties
+        self.ctx.params["segment_event_prefix"] = 'WZ PMKExpress CLI'
+        self.ctx.params["segment_subcommand"] = segment_subcommand
+        self.ctx.params["segment_step_count"] = 1
+
+    def send_track(self, step_name):
+        """ Builds event name based on subcommand and step count
+        """
+        event_name = " - ".join([self.ctx.params["segment_event_prefix"], self.ctx.params["segment_subcommand"],
+                              step_name, str(self.ctx.params["segment_step_count"])])
+        self.ctx.params["segment_step_count"] = self.ctx.params["segment_step_count"] + 1
+        self.ctx.params["segment_session"].send_track(event_name, self.ctx.params["segment_event_properties"], user_id=self.ctx.params['user_id'])
+
+    def send_track_error(self, step_name, error_message):
+        error_event_name = " - ".join([self.ctx.params["segment_event_prefix"], self.ctx.params["segment_subcommand"],
+                                 step_name, "ERROR"])
+        segment_properties = self.ctx.params["segment_event_properties"].copy()
+        segment_properties.update(dict(error_message=error_message))
+        self.ctx.params["segment_session"].send_track(error_event_name, segment_properties,
+                                                      user_id=self.ctx.params['user_id'])
+
+
+class SegmentSession:
+
+    def __init__(self):
+        # unique for the device
+        self.device_id = str(uuid.uuid3(uuid.NAMESPACE_DNS, str(uuid.getnode())))
+
+        # unique for this session
+        self.anonymous_id = str(uuid.uuid1())
+
+        # Session time is time in EPOC that must be passed to Segment in each track event to ensure that a single
+        # session is maintained. The client side CLI should generate this and submit the string with each API submission
+        self.session_time = math.floor(time.time())
+
+    def send_track(self, event_name, event_properties, user_id=None):
+        track_dict = {
+            'anonymous_id': self.anonymous_id,
+            'wizard_name': event_name,
+            'installation_id': self.device_id,
+            'deployment_type': 'BareOS'
+        }
+        # append event_properties to track_dict as is
+        track_dict.update(event_properties)
+        track_user_id = self.anonymous_id
+        if user_id:
+            track_dict['user_id'] = user_id
+            track_user_id = user_id
+        try:
+            analytics.track(track_user_id, event_name, track_dict,
+                anonymous_id=self.anonymous_id,
+                # The 'integrations array begin passed below is how the 'session' identifier is passed into Amplitude
+                integrations={
+                    'Amplitude': {
+                        'session_id': self.session_time
+                    }
+                }
+            )
+        except Exception as except_err:
+            logger.error("Exception in send_track while communicating to segment")
+            logger.exception(except_err)
+
+    def send_identify(self, email, user_id):
+        try:
+            analytics.identify(user_id, {
+                'anonymous_id': self.anonymous_id,
+                'installation_id': self.device_id,
+                'email': email,
+                'user_id': user_id,
+                'deviceId': user_id,
+                # all DATE and TIME submissions need to be in ISO 8601 format
+                'createdAt': datetime.datetime.now().isoformat(),
+                },
+               anonymous_id=self.anonymous_id,
+            )
+            # Associate old unauthenticated events to post-authenticated events
+            analytics.alias(self.anonymous_id, user_id)
+        except Exception as except_err:
+            logger.error("Exception in send_identify while communicating to segment")
+            logger.exception(except_err)

--- a/pf9/modules/express.py
+++ b/pf9/modules/express.py
@@ -50,7 +50,8 @@ class Get:
     """Express.Get(ctx) contains method to "GET" data required to run express"""
     def __init__(self, ctx):
         self.ctx = ctx
-        
+
+
     def get_token_project(self):
         """Calls ostoken.GetToken().get_token_project() using active config
                 return token, project_id
@@ -68,6 +69,30 @@ class Get:
             # Add token and project_id to ctx and return token_project
             self.ctx.params['token'], self.ctx.params['project_id'] = token_project
             return token_project
+        except UserAuthFailure as except_msg:
+            logger.exception(except_msg)
+            raise
+        except CLIException as except_err:
+            logger.exception(except_err)
+            raise except_err
+
+    def get_token_project_user_id(self):
+        """Calls ostoken.GetToken().get_token_project() using active config
+                return token, project_id
+        """
+        try:
+            self.active_config()
+            token_project_user_id = GetToken().get_token_project_user_id(
+                self.ctx.params["du_url"],
+                self.ctx.params["du_username"],
+                self.ctx.params["du_password"],
+                self.ctx.params["du_tenant"])
+            if not token_project_user_id:
+                except_err = "Failed to obtain an Authentication Token from: {}".format(self.ctx.params["du_url"])
+                raise CLIException(except_err)
+            # Add token and project_id to ctx and return token_project
+            self.ctx.params['token'], self.ctx.params['project_id'], self.ctx.params['user_id'] = token_project_user_id
+            return token_project_user_id
         except UserAuthFailure as except_msg:
             logger.exception(except_msg)
             raise

--- a/pf9/modules/ostoken.py
+++ b/pf9/modules/ostoken.py
@@ -78,6 +78,13 @@ class GetToken:
         project_id = os_auth_req['json']['token']['project']['id']
         return token, project_id
 
+    def get_token_project_user_id(self, host, username, password, tenant):
+        os_auth_req = self.os_auth(host, username, password, tenant)
+        token = os_auth_req['headers']['X-Subject-Token']
+        project_id = os_auth_req['json']['token']['project']['id']
+        user_id = os_auth_req['json']['token']['user']['id']
+        return token, project_id, user_id
+
 
 class GetRegionURL:
     """GetRegionURL Returns FQDN of a public API service endpoint for a given Openstack Region"""

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,8 @@ setup(
                       'paramiko',
                       'fabric',
                       'invoke',
-                      'ansible'
+                      'ansible',
+                      'analytics-python'
                       ],
     extras_require={
         'test': ['coverage', 'pytest', 'pytest-cov', 'mock'],


### PR DESCRIPTION
All cluster subcommands are instrumented to send analytics to Segment with all the arguments, keystone user id and account URL. Currently, it tracks only completed steps and doesn't track error cases and messages, which will be added in the future.