### PR TITLE
Instrumentation of Error cases for cluster commands, grouping based o…

### DIFF
--- a/pf9/cluster/cluster_attach.py
+++ b/pf9/cluster/cluster_attach.py
@@ -4,7 +4,7 @@ import requests
 import json
 import click
 
-from pf9.cluster.exceptions import ClusterAttachFailed, FailedActiveMasters, ClusterNotAvailable, CLIException
+from pf9.cluster.exceptions import ClusterAttachFailed, FailedActiveMasters, ClusterNotAvailable, NodeNotFound
 from pf9.modules.util import Logger
 from pf9.modules.express import Get
 
@@ -127,7 +127,7 @@ class AttachCluster(object):
                 error_msg = "Unable to find host with IP:{}, please try again or run prep-node first".format(host_ip)
                 logger.error(error_msg)
                 click.echo(error_msg)
-                raise CLIException(error_msg)
+                raise NodeNotFound(error_msg)
         return host_uuids
 
     def cluster_convergence_status(self, cluster_uuid):

--- a/pf9/cluster/cluster_attach.py
+++ b/pf9/cluster/cluster_attach.py
@@ -4,7 +4,7 @@ import requests
 import json
 import click
 
-from pf9.cluster.exceptions import ClusterAttachFailed, FailedActiveMasters, ClusterNotAvailable
+from pf9.cluster.exceptions import ClusterAttachFailed, FailedActiveMasters, ClusterNotAvailable, CLIException
 from pf9.modules.util import Logger
 from pf9.modules.express import Get
 
@@ -124,8 +124,10 @@ class AttachCluster(object):
             if host_uuid is not None:
                 host_uuids.append(host_uuid)
             else:
-                logger.info("Unable to find host with IP:{}, please try again or run prep-node first".format(host_ip))
-                click.echo("Unable to find host with IP:{}, please try again or run prep-node first".format(host_ip))
+                error_msg = "Unable to find host with IP:{}, please try again or run prep-node first".format(host_ip)
+                logger.error(error_msg)
+                click.echo(error_msg)
+                raise CLIException(error_msg)
         return host_uuids
 
     def cluster_convergence_status(self, cluster_uuid):

--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -130,9 +130,7 @@ def attach_cluster(cluster_name, master_ips, worker_ips, ctx):
             cluster_attacher.wait_for_n_active_masters(len(master_nodes))
         except (ClusterAttachFailed, ClusterNotAvailable) as except_err:
             logger.exception(except_err)
-            error_msg = "Failed attaching master node(s) to cluster: {}".format(except_err)
-            click.echo(error_msg)
-            SegmentSessionWrapper(ctx).send_track_error('Cluster Attach', error_msg)
+            click.echo("Failed attaching master node(s) to cluster: {}".format(except_err))
             raise except_err
     SegmentSessionWrapper(ctx).send_track("Attach Master Nodes")
 
@@ -142,9 +140,7 @@ def attach_cluster(cluster_name, master_ips, worker_ips, ctx):
             cluster_attacher.attach_to_cluster(cluster_uuid, 'worker', worker_nodes)
         except (ClusterAttachFailed, ClusterNotAvailable) as except_err:
             logger.exception(except_err)
-            error_msg = "Failed attaching worker node(s) to cluster: {}".format(except_err)
-            click.echo(error_msg)
-            SegmentSessionWrapper(ctx).send_track_error('Cluster Attach', error_msg)
+            click.echo("Failed attaching master node(s) to cluster: {}".format(except_err))
             raise except_err
     SegmentSessionWrapper(ctx).send_track("Attach Worker Nodes")
 

--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -89,8 +89,10 @@ def attach_cluster(cluster_name, master_ips, worker_ips, ctx):
     click.echo("Attaching to cluster {}".format(cluster_name))
     status, cluster_uuid = CreateCluster(ctx).cluster_exists()
     if not status:
-        click.secho("Cluster {} doesn't exist. Provide name of an existing cluster".format(
-                    ctx.params['cluster_name']), fg="red")
+        msg = "Cluster {} doesn't exist. Provide name of an existing cluster".format(
+                    ctx.params['cluster_name'])
+        click.secho(msg, fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Cluster Existence', msg)
         sys.exit(1)
 
     SegmentSessionWrapper(ctx).send_track("Validate Cluster Existence")
@@ -128,7 +130,10 @@ def attach_cluster(cluster_name, master_ips, worker_ips, ctx):
             cluster_attacher.wait_for_n_active_masters(len(master_nodes))
         except (ClusterAttachFailed, ClusterNotAvailable) as except_err:
             logger.exception(except_err)
-            click.echo("Failed attaching master node(s) to cluster: {}".format(except_err))
+            error_msg = "Failed attaching master node(s) to cluster: {}".format(except_err)
+            click.echo(error_msg)
+            SegmentSessionWrapper(ctx).send_track_error('Cluster Attach', error_msg)
+            raise except_err
     SegmentSessionWrapper(ctx).send_track("Attach Master Nodes")
 
     # attach worker nodes
@@ -137,7 +142,10 @@ def attach_cluster(cluster_name, master_ips, worker_ips, ctx):
             cluster_attacher.attach_to_cluster(cluster_uuid, 'worker', worker_nodes)
         except (ClusterAttachFailed, ClusterNotAvailable) as except_err:
             logger.exception(except_err)
-            click.echo("Failed attaching worker node(s) to cluster: {}".format(except_err))
+            error_msg = "Failed attaching worker node(s) to cluster: {}".format(except_err)
+            click.echo(error_msg)
+            SegmentSessionWrapper(ctx).send_track_error('Cluster Attach', error_msg)
+            raise except_err
     SegmentSessionWrapper(ctx).send_track("Attach Worker Nodes")
 
 @click.group()
@@ -180,10 +188,6 @@ def create(ctx, **kwargs):
     """Create a Kubernetes cluster. Read more at http://pf9.io/cli_clcreate."""
     logger.info(msg=click.get_current_context().info_name)
 
-    # Load active config
-    Get(ctx).active_config()
-    Get(ctx).get_token_project_user_id()
-
     segment_session = SegmentSession()
     segment_event_properties = dict(arg_cluster_name=ctx.params['cluster_name'],
                                     arg_master_ips=ctx.params['master_ip'],
@@ -200,12 +204,23 @@ def create(ctx, **kwargs):
                                     arg_appCatalogEnabled=ctx.params.get('appcatalogenabled', None),
                                     arg_allowWorkloadsOnMaster=ctx.params.get('allowworkloadsonmaster', None),
                                     arg_networkPlugin=ctx.params.get('networkplugin', None),
-                                    arg_floating_ip=ctx.params.get('floating_ip', None),
-                                    keystone_user_id=ctx.params['user_id'],
-                                    du_account_url=ctx.params['du_url'])
+                                    arg_floating_ip=ctx.params.get('floating_ip', None))
     SegmentSessionWrapper(ctx).load_segment_session(segment_session, segment_event_properties, "Create Cluster")
+
+    try:
+        # Load active config
+        Get(ctx).active_config()
+        # Validate and get token
+        Get(ctx).get_token_project_user_id()
+    except Exception as e:
+        click.secho("Failed to create cluster {}. {}".format(ctx.params['cluster_name'], e.msg), fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Load Active config', e)
+        sys.exit(1)
+
+    SegmentSessionWrapper(ctx).reload_segment_session_with_auth()
     SegmentSessionWrapper(ctx).send_track("Load Active config")
     segment_session.send_identify(ctx.params['du_username'], ctx.params['user_id'])
+    segment_session.send_group(ctx.params['user_id'], ctx.params['du_url'])
 
     master_ips = ctx.params['master_ip']
     ctx.params['master_ip'] = ''.join(master_ips).split(' ') if all(len(x) == 1
@@ -285,6 +300,7 @@ def create(ctx, **kwargs):
         logger.exception("Cluster Create Failed")
         click.secho("Failed to create cluster {}. {}".format(
                     ctx.params['cluster_name'], e.msg), fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Cluster Create', e)
         sys.exit(1)
 
     response = ""
@@ -330,12 +346,9 @@ def bootstrap(ctx, **kwargs):
     """
     logger.info(msg=click.get_current_context().info_name)
 
-    # Load active config
-    Get(ctx).active_config()
-    Get(ctx).get_token_project_user_id()
-
     segment_session = SegmentSession()
-    segment_event_properties = dict(arg_cluster_name=ctx.params['cluster_name'], arg_masterVip=ctx.params.get('mastervip', None),
+    segment_event_properties = dict(arg_cluster_name=ctx.params['cluster_name'],
+                                    arg_masterVip=ctx.params.get('mastervip', None),
                                     arg_masterVipIf=ctx.params.get('mastervipif', None),
                                     arg_metallbIpRange=ctx.params.get('metallbiprange', None),
                                     arg_containersCidr=ctx.params.get('containerscidr', None),
@@ -345,12 +358,24 @@ def bootstrap(ctx, **kwargs):
                                     arg_appCatalogEnabled=ctx.params.get('appcatalogenabled', None),
                                     arg_allowWorkloadsOnMaster=ctx.params.get('allowworkloadsonmaster', None),
                                     arg_networkPlugin=ctx.params.get('networkplugin', None),
-                                    arg_floating_ip=ctx.params.get('floating_ip', None),
-                                    keystone_user_id=ctx.params['user_id'],
-                                    du_account_url=ctx.params['du_url'])
+                                    arg_floating_ip=ctx.params.get('floating_ip', None))
     SegmentSessionWrapper(ctx).load_segment_session(segment_session, segment_event_properties, "Bootstrap Cluster")
+
+    try:
+        # Load active config
+        Get(ctx).active_config()
+        # Validate Token
+        Get(ctx).get_token_project_user_id()
+    except Exception as e:
+        click.secho("Encountered an error while bootstrapping the local node to a Kubernetes" \
+                    " cluster. {}".format(e.msg), fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Load Active config', e)
+        sys.exit(1)
+
+    SegmentSessionWrapper(ctx).reload_segment_session_with_auth()
     SegmentSessionWrapper(ctx).send_track("Load Active config")
     segment_session.send_identify(ctx.params['du_username'], ctx.params['user_id'])
+    segment_session.send_group(ctx.params['user_id'], ctx.params['du_url'])
 
     prompt_msg = "Proceed with creating a Kubernetes cluster with the current node as the Kubernetes master [y/n]?"
     localnode_confirm = click.prompt(prompt_msg, default='y')
@@ -383,6 +408,7 @@ def bootstrap(ctx, **kwargs):
         logger.exception("Bootstrap Failed")
         click.secho("Encountered an error while bootstrapping the local node to a Kubernetes"\
                     " cluster. {}".format(e.msg), fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Bootstrap', 'Error while bootstrapping: {}'.format(e))
         sys.exit(1)
 
     SegmentSessionWrapper(ctx).send_track("Bootstrap Complete")
@@ -406,19 +432,27 @@ def attach_node(ctx, **kwargs):
     """
     logger.info(msg=click.get_current_context().info_name)
 
-    # Load active config
-    Get(ctx).active_config()
-    # Validate Token
-    Get(ctx).get_token_project_user_id()
-
     segment_session = SegmentSession()
     segment_event_properties = dict(arg_cluster_name=ctx.params['cluster_name'], arg_master_ips=ctx.params['master_ip'],
-                                    arg_worker_ips=ctx.params['worker_ip'], arg_floating_ip=ctx.params['floating_ip'],
-                                    keystone_user_id=ctx.params['user_id'],
-                                    du_account_url=ctx.params['du_url'])
+                                    arg_worker_ips=ctx.params['worker_ip'], arg_floating_ip=ctx.params['floating_ip'])
     SegmentSessionWrapper(ctx).load_segment_session(segment_session, segment_event_properties, "Attach Node")
-    SegmentSessionWrapper(ctx).send_track("Load Active config")
+
+    try:
+        # Load active config
+        Get(ctx).active_config()
+        # Validate Token
+        Get(ctx).get_token_project_user_id()
+    except Exception as e:
+        error_msg = "Encountered an error while attaching nodes to a Kubernetes" \
+                    " cluster {}. {}".format(ctx.params['cluster_name'], e.msg)
+        click.secho(error_msg, fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Load Active config', e)
+        sys.exit(1)
+
+    SegmentSessionWrapper(ctx).reload_segment_session_with_auth()
+    SegmentSessionWrapper(ctx).send_track('Load Active config')
     segment_session.send_identify(ctx.params['du_username'], ctx.params['user_id'])
+    segment_session.send_group(ctx.params['user_id'], ctx.params['du_url'])
 
     if not ctx.params['master_ip'] and not ctx.params['worker_ip']:
         msg = "No nodes were specified to be attached to the cluster {}."
@@ -448,8 +482,10 @@ def attach_node(ctx, **kwargs):
         SegmentSessionWrapper(ctx).send_track("Attach Cluster Complete")
     except CLIException as e:
         logger.exception("Cluster Attach Failed")
-        click.secho("Encountered an error while attaching nodes to a Kubernetes"\
-                    " cluster {}. {}".format(ctx.params['cluster_name'], e.msg), fg="red")
+        error_msg = "Encountered an error while attaching nodes to a Kubernetes"\
+                    " cluster {}. {}".format(ctx.params['cluster_name'], e.msg)
+        click.secho(error_msg, fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Cluster Attach', error_msg)
         sys.exit(1)
 
     click.secho("Successfully attached nodes to a Kubernetes cluster {} "\
@@ -474,18 +510,26 @@ def prepnode(ctx, user, password, ssh_key, ips, floating_ip):
     """
     logger.info(msg=click.get_current_context().info_name)
 
-    # Load active config
-    Get(ctx).active_config()
-    # Validate Token
-    Get(ctx).get_token_project_user_id()
-
     segment_session = SegmentSession()
     segment_event_properties = dict(arg_user='REDACTED', arg_password='REDACTED', arg_ssh_key=ssh_key,
-                                    arg_ips=ips, arg_floating_ip=floating_ip, keystone_user_id=ctx.params['user_id'],
-                                    du_account_url=ctx.params['du_url'])
+                                    arg_ips=ips, arg_floating_ip=floating_ip)
     SegmentSessionWrapper(ctx).load_segment_session(segment_session, segment_event_properties, "Prep Node")
+
+    try:
+        # Load active config
+        Get(ctx).active_config()
+        # Validate Token
+        Get(ctx).get_token_project_user_id()
+    except Exception as e:
+        click.secho("Encountered an error while preparing the provided nodes as "
+                    "Kubernetes nodes. {}".format(e), fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Load Active config', e)
+        sys.exit(1)
+
+    SegmentSessionWrapper(ctx).reload_segment_session_with_auth()
     SegmentSessionWrapper(ctx).send_track('Load Active config')
     segment_session.send_identify(ctx.params['du_username'], ctx.params['user_id'])
+    segment_session.send_group(ctx.params['user_id'], ctx.params['du_url'])
 
     if not ips:
         prompt_msg = "No IPs provided. " \
@@ -510,6 +554,7 @@ def prepnode(ctx, user, password, ssh_key, ips, floating_ip):
                     validate_ssh_details(user, password, ssh_key)
                 except CLIException as e:
                     logger.exception("SSH Validation Failed")
+                    SegmentSessionWrapper(ctx).send_track_error('SSH Validation', e.message)
                     click.secho(e.msg, fg="red")
                     print_help_msg(prepnode)
                     sys.exit(1)
@@ -525,6 +570,7 @@ def prepnode(ctx, user, password, ssh_key, ips, floating_ip):
         logger.exception("Encountered an error while preparing the provided nodes as Kubernetes nodes.")
         click.secho("Encountered an error while preparing the provided nodes as "
                     "Kubernetes nodes. {}".format(e.msg), fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('Prep Node', e.message)
         sys.exit(1)
 
     click.secho("Preparing the provided nodes to be added to Kubernetes cluster was successful",

--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -378,6 +378,8 @@ def bootstrap(ctx, **kwargs):
 
     if localnode_confirm.lower() == 'n':
         click.secho("Quitting...", fg="red")
+        SegmentSessionWrapper(ctx).send_track_abort('CLUSTER BOOTSTRAP',
+                                                    'Declined to proceed with creating a Kubernetes cluster with the current node as the Kubernetes master')
         sys.exit(1)
 
     try:
@@ -451,8 +453,9 @@ def attach_node(ctx, **kwargs):
     segment_session.send_group(ctx.params['user_id'], ctx.params['du_url'])
 
     if not ctx.params['master_ip'] and not ctx.params['worker_ip']:
-        msg = "No nodes were specified to be attached to the cluster {}."
+        msg = "No nodes were specified to be attached to the cluster {}.".format(ctx.params['cluster_name'])
         click.secho(msg.format(ctx.params['cluster_name']), fg="red")
+        SegmentSessionWrapper(ctx).send_track_error('No Nodes', msg)
         sys.exit(1)
 
     master_ips = ()
@@ -532,6 +535,8 @@ def prepnode(ctx, user, password, ssh_key, ips, floating_ip):
                      "Proceed with preparing the current node to be added to a Kubernetes cluster [y/n]?"
         localnode_confirm = click.prompt(prompt_msg, default='y')
         if localnode_confirm.lower() == 'n':
+            SegmentSessionWrapper(ctx).send_track_abort('Prep Node',
+                                                        'Declined to proceed with preparing the current node to be added to a Kubernetes cluster')
             sys.exit(1)
         else:
             ips = ("localhost",)

--- a/pf9/cluster/exceptions.py
+++ b/pf9/cluster/exceptions.py
@@ -40,6 +40,11 @@ class ClusterNotAvailable(ClusterCLIException):
         super(ClusterNotAvailable, self).__init__(msg)
 
 
+class NodeNotFound(ClusterCLIException):
+    def __init__(self, msg):
+        super(NodeNotFound, self).__init__(msg)
+
+
 class FailedActiveMasters(ClusterCLIException):
     def __init__(self, msg):
         super(FailedActiveMasters, self).__init__(msg)

--- a/pf9/modules/analytics_utils.py
+++ b/pf9/modules/analytics_utils.py
@@ -54,6 +54,15 @@ class SegmentSessionWrapper:
         self.ctx.params["segment_session"].send_track(error_event_name, segment_properties,
                                                       user_id=self.ctx.params.get('user_id', None))
 
+    def send_track_abort(self, step_name, abort_message):
+        error_event_name = " - ".join([self.ctx.params["segment_event_prefix"], self.ctx.params["segment_subcommand"],
+                                 "ABORT"])
+        segment_properties = self.ctx.params["segment_event_properties"].copy()
+        segment_properties.update(dict(abort_name=step_name, abort_message=str(abort_message)))
+        # its possible that this was an Authentication Failure, so it might not have user_id
+        self.ctx.params["segment_session"].send_track(error_event_name, segment_properties,
+                                                      user_id=self.ctx.params.get('user_id', None))
+
 
 class SegmentSession:
 

--- a/pf9/modules/analytics_utils.py
+++ b/pf9/modules/analytics_utils.py
@@ -27,7 +27,10 @@ class SegmentSessionWrapper:
 
     def reload_segment_session_with_auth(self):
         """
-            Reload Segment Session with DU URL and Keystone User ID after keystone Auth
+            Reload Segment Session with DU URL and Keystone User ID after keystone Auth.
+            This is needed to add keystone user_id and account_url to the segment event properties post initialization.
+            As we want to capture pre Auth Failures/Errors, we should be able to send events to segment pre auth
+            and pre config load, during which we wont have keystone user_id / du_account_url.
         """
         segment_event_properties = self.ctx.params["segment_event_properties"]
         segment_event_properties.update(du_account_url=self.ctx.params['du_url'])

--- a/pf9/modules/analytics_utils.py
+++ b/pf9/modules/analytics_utils.py
@@ -8,7 +8,7 @@ from pf9.modules.util import Utils, Logger
 
 logger = Logger(os.path.join(os.path.expanduser("~"), 'pf9/log/pf9ctl.log')).get_logger(__name__)
 
-# the write_key is the Segment API authorization and identifier, without this no data submission will work. The API Key below is for Dev/Test work
+# the write_key is the Segment API authorization and identifier, without this no data submission will work.
 analytics.write_key = 'qDQpEaZQnDgqpXXG6jiV7OlZGqYZlQAa'
 
 
@@ -25,6 +25,15 @@ class SegmentSessionWrapper:
         self.ctx.params["segment_subcommand"] = segment_subcommand
         self.ctx.params["segment_step_count"] = 1
 
+    def reload_segment_session_with_auth(self):
+        """
+            Reload Segment Session with DU URL and Keystone User ID after keystone Auth
+        """
+        segment_event_properties = self.ctx.params["segment_event_properties"]
+        segment_event_properties.update(du_account_url=self.ctx.params['du_url'])
+        segment_event_properties.update(keystone_user_id=self.ctx.params['user_id'])
+        self.ctx.params["segment_event_properties"] = segment_event_properties
+
     def send_track(self, step_name):
         """ Builds event name based on subcommand and step count
         """
@@ -35,11 +44,12 @@ class SegmentSessionWrapper:
 
     def send_track_error(self, step_name, error_message):
         error_event_name = " - ".join([self.ctx.params["segment_event_prefix"], self.ctx.params["segment_subcommand"],
-                                 step_name, "ERROR"])
+                                 "ERROR"])
         segment_properties = self.ctx.params["segment_event_properties"].copy()
-        segment_properties.update(dict(error_message=error_message))
+        segment_properties.update(dict(error_name=step_name, error_message=str(error_message)))
+        # its possible that this was an Authentication Failure, so it might not have user_id
         self.ctx.params["segment_session"].send_track(error_event_name, segment_properties,
-                                                      user_id=self.ctx.params['user_id'])
+                                                      user_id=self.ctx.params.get('user_id', None))
 
 
 class SegmentSession:
@@ -99,4 +109,13 @@ class SegmentSession:
             analytics.alias(self.anonymous_id, user_id)
         except Exception as except_err:
             logger.error("Exception in send_identify while communicating to segment")
+            logger.exception(except_err)
+
+    def send_group(self, user_id, du_account_url):
+        try:
+            analytics.group(user_id, du_account_url, traits={'ddu_url_': 'DU', 'account_url_': du_account_url,
+                                                             'cli_last_executed_at': datetime.datetime.now().isoformat()},
+                            anonymous_id=self.anonymous_id)
+        except Exception as except_err:
+            logger.error("Exception in send_group while communicating to segment")
             logger.exception(except_err)


### PR DESCRIPTION
…n DU URL and exception when node UUID not found

This PR does the following:
1. Ships all the exceptions/error that happen when a user runs cluster commands to Segment.
2. Groups the users to accounts using keystone user_id and du account url
3. Handles a case where if a master node/worker node's UUID was not found, will throw an exception and immediately exit.

Tested manually on my dev vm.