### PR TITLE
added dev-key and disable-analytics options to pmkft cli

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -98,6 +98,14 @@ parse_args() {
                 dev_build="--dev"
                 shift
                 ;;
+            --dev-key)
+                dev_key="--dev-key"
+                shift
+                ;;
+            --disable-analytics)
+                disable_analytics="--disable-analytics"
+                shift
+                ;;
             --local)
                 run_local="--local"
                 shift
@@ -257,11 +265,11 @@ create_cli_config(){
 	    stdout_log "Attempt $auth_retry of ${max_auth_retry}:"; fi
 
     if [ ! -z "${PF9_MGMTURL}" ] && [ ! -z "${PF9_USER}" ] && [ ! -z "${PF9_PASS}" ] && [ ! -z "${PF9_REGION}" ] && [ ! -z "${PF9_TENANT}" ]; then
-        eval "${cli_exec}" config create --du_url ${PF9_MGMTURL} --os_username ${PF9_USER} --os_password ${PF9_PASS} --os_region ${PF9_REGION} --os_tenant ${PF9_TENANT}
+        eval "${cli_exec}" config create --du_url ${PF9_MGMTURL} --os_username ${PF9_USER} --os_password ${PF9_PASS} --os_region ${PF9_REGION} --os_tenant ${PF9_TENANT} ${dev_key} ${disable_analytics}
     else
         echo ""
         stdout_log "Please provide your Platform9 Credentials"
-        eval "${cli_exec}" config create
+        eval "${cli_exec}" config create ${dev_key} ${disable_analytics}
     fi
 
 	if (${cli_exec} config validate); then

--- a/pf9/config/commands.py
+++ b/pf9/config/commands.py
@@ -27,8 +27,10 @@ def config(ctx):
 @click.option('--os_password', required=True, prompt='Password', hide_input=True)
 @click.option('--os_region', required=True, prompt='Enter Region & Tenant Details (Freedom Plan requires RegionOne and service)\nRegion', default='RegionOne')
 @click.option('--os_tenant', required=True, prompt='Tenant', default='service')
+@click.option('--dev-key', is_flag=True)
+@click.option('--disable-analytics', is_flag=True)
 @click.pass_context
-def create(ctx, du_url, os_username, os_password, os_region, os_tenant):
+def create(ctx, du_url, os_username, os_password, os_region, os_tenant, dev_key, disable_analytics):
     """Create Platform9 management plane config."""
     # creates and activates pf9-express config file
     logger.info(msg=click.get_current_context().info_name)

--- a/pf9/config/commands.py
+++ b/pf9/config/commands.py
@@ -27,8 +27,8 @@ def config(ctx):
 @click.option('--os_password', required=True, prompt='Password', hide_input=True)
 @click.option('--os_region', required=True, prompt='Enter Region & Tenant Details (Freedom Plan requires RegionOne and service)\nRegion', default='RegionOne')
 @click.option('--os_tenant', required=True, prompt='Tenant', default='service')
-@click.option('--dev-key', is_flag=True)
-@click.option('--disable-analytics', is_flag=True)
+@click.option('--dev-key', is_flag=True, hidden=True)
+@click.option('--disable-analytics', is_flag=True, hidden=True)
 @click.pass_context
 def create(ctx, du_url, os_username, os_password, os_region, os_tenant, dev_key, disable_analytics):
     """Create Platform9 management plane config."""

--- a/pf9/modules/express.py
+++ b/pf9/modules/express.py
@@ -178,6 +178,16 @@ class Get:
                     self.ctx.params['du_password'] = config["os_password"]
                     self.ctx.params['du_tenant'] = config["os_tenant"]
                     self.ctx.params['du_region'] = config["os_region"]
+                    # This is needed if we want them to be loaded as python bool
+                    if config.get("dev_key") == 'True':
+                        self.ctx.params['dev_key'] = True
+                    else:
+                        self.ctx.params['dev_key'] = False
+                    if config.get("disable_analytics") == 'True':
+                        self.ctx.params['disable_analytics'] = True
+                    else:
+                        self.ctx.params['disable_analytics'] = False
+
                 return self.ctx
             except Exception as except_err:
                 except_msg = "Failed parsing active config {}: ".format(config_file)
@@ -227,6 +237,12 @@ class Get:
             if 'manage_resolver' in line:
                 line = line.strip()
                 config.update({'manage_resolver': line.replace('manage_resolver|', '')})
+            if 'dev_key' in line:
+                line = line.strip()
+                config.update({'dev_key': line.replace('dev_key|', '')})
+            if 'disable_analytics' in line:
+                line = line.strip()
+                config.update({'disable_analytics': line.replace('disable_analytics|', '')})
         return config
 
 


### PR DESCRIPTION
--dev-key uses dev/test key
--disable-analytics disables sending of data to segment

These 2 options can be used from pf9ctl config create or cli-setup.sh.

Tested on my Dev VM and a new installation of express-cli