### PR TITLE
Hide version command in the CLI

### DIFF
--- a/pf9/express.py
+++ b/pf9/express.py
@@ -42,7 +42,7 @@ def cli(ctx):
 # Any commands defined here or added will be toplevel
 
 
-cli.add_command(version)
+# cli.add_command(version)
 cli.add_command(config)
 cli.add_command(support)
 cli.add_command(cluster)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ import logging
 import inspect
 from subprocess import PIPE, Popen as popen
 
-from unittest import TestCase
+from unittest import TestCase, skip
 from click.testing import CliRunner
 
 from pf9 import __version__
@@ -23,6 +23,7 @@ class TestHelp(TestCase):
 
 class TestExpCliVersion(TestCase):
     """Test express --version call"""
+    @skip("Skip disabled CLI version command")
     def test_returns_version_information(self):
         """Test express --version call"""
         runner = CliRunner()


### PR DESCRIPTION
The version command doesn't make sense anymore after the rewrite. Removing it
from the list of commands.