### PR TITLE
Lock ansible version to 2.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
                       'paramiko',
                       'fabric',
                       'invoke',
-                      'ansible',
+                      'ansible==2.9.13',
                       'analytics-python'
                       ],
     extras_require={


### PR DESCRIPTION
Latest ansible release 2.10 breaks ansible upgrades from previous versions. Lock
the previous version till the CLI can figure out a cleaner upgrade path to the
newer version.