### PR TITLE
Get support logs when CLI fails

### DIFF
--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -58,7 +58,6 @@ def prep_node(ctx, user, password, ssh_key, ips, node_prep_only):
             msg = "Code: {}, output log: {}".format(cmd_proc.returncode, log_file)
             raise PrepNodeFailed(msg,ctx,ips,user,password)
 
-
         return cmd_proc.returncode, log_file
 
 
@@ -574,3 +573,4 @@ def prepnode(ctx, user, password, ssh_key, ips, floating_ip):
         sys.exit(1)
     click.secho("Preparing the provided nodes to be added to Kubernetes cluster was successful",
                 fg="green")
+

--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -56,7 +56,7 @@ def prep_node(ctx, user, password, ssh_key, ips, node_prep_only):
 
         if cmd_proc.returncode:
             msg = "Code: {}, output log: {}".format(cmd_proc.returncode, log_file)
-            raise PrepNodeFailed(msg,ctx,ips,user,password)
+            raise PrepNodeFailed(msg, ctx, ips, user, password)
 
         return cmd_proc.returncode, log_file
 

--- a/pf9/cluster/commands.py
+++ b/pf9/cluster/commands.py
@@ -13,7 +13,6 @@ from pf9.cluster.exceptions import PrepNodeFailed, ClusterNotAvailable, ClusterA
 from pf9.cluster.helpers import validate_ssh_details, get_local_node_addresses, check_vip_needed, print_help_msg
 from pf9.cluster.cluster_create import CreateCluster
 from pf9.cluster.cluster_attach import AttachCluster
-#from pf9.cluster.zendesk import CreateTicket
 from ..modules.express import Get
 from ..modules.analytics_utils import SegmentSession, SegmentSessionWrapper
 from pf9.support.generate_bundle import Log_Bundle
@@ -34,7 +33,6 @@ def prep_node(ctx, user, password, ssh_key, ips, node_prep_only):
     log_file = os.path.join(ctx.obj['pf9_log_dir'],
                             datetime.now().strftime('node_provision_%Y_%m_%d-%H_%M_%S.log'))
     os.environ['ANSIBLE_CONFIG'] = ctx.obj['pf9_ansible_cfg']
-
     SegmentSessionWrapper(ctx).send_track('Prep Express Run')
 
     # Progress bar logic: estimate total time, while cmd_proc running, poll at interval, refreshing progbar
@@ -58,8 +56,7 @@ def prep_node(ctx, user, password, ssh_key, ips, node_prep_only):
 
         if cmd_proc.returncode:
             msg = "Code: {}, output log: {}".format(cmd_proc.returncode, log_file)
-
-            raise PrepNodeFailed(msg,ctx,ips)
+            raise PrepNodeFailed(msg,ctx,ips,user,password)
 
 
         return cmd_proc.returncode, log_file
@@ -344,7 +341,6 @@ def bootstrap(ctx, **kwargs):
     Read more at http://pf9.io/cli_clbootstrap.
     """
     logger.info(msg=click.get_current_context().info_name)
-    print (ctx.params)
     segment_session = SegmentSession()
     segment_event_properties = dict(arg_cluster_name=ctx.params['cluster_name'],
                                     arg_masterVip=ctx.params.get('mastervip', None),
@@ -409,7 +405,6 @@ def bootstrap(ctx, **kwargs):
         logger.exception("Bootstrap Failed")
         click.secho("Encountered an error while bootstrapping the local node to a Kubernetes"\
                     " cluster. {}".format(e.msg), fg="red")
-
         SegmentSessionWrapper(ctx).send_track_error('Bootstrap', 'Error while bootstrapping: {}'.format(e))
         sys.exit(1)
 
@@ -553,7 +548,6 @@ def prepnode(ctx, user, password, ssh_key, ips, floating_ip):
         for ip in parse_ips:
             if ip == "127.0.0.1" or ip == "localhost" or ip in get_local_node_addresses():
                 adj_ips = adj_ips + ("localhost",)
-
             else:
                 # check if ssh creds are provided.
                 try:
@@ -567,21 +561,16 @@ def prepnode(ctx, user, password, ssh_key, ips, floating_ip):
 
                 adj_ips = adj_ips + (ip,)
 
-
         SegmentSessionWrapper(ctx).send_track('Node IPs validation')
 
         prep_node(ctx, user, password, ssh_key, adj_ips, node_prep_only=True)
 
         SegmentSessionWrapper(ctx).send_track('Prep Node Complete')
     except CLIException as e:
-
         logger.exception("Encountered an error while preparing the provided nodes as Kubernetes nodes.")
         click.secho("Encountered an error while preparing the provided nodes as "
                     "Kubernetes nodes. {}".format(e.msg), fg="red")
-
         SegmentSessionWrapper(ctx).send_track_error('Prep Node', e)
-
         sys.exit(1)
-
     click.secho("Preparing the provided nodes to be added to Kubernetes cluster was successful",
                 fg="green")

--- a/pf9/cluster/exceptions.py
+++ b/pf9/cluster/exceptions.py
@@ -36,8 +36,6 @@ class ClusterAttachFailed(ClusterCLIException):
         super(ClusterAttachFailed, self).__init__(msg)
 
 
-
-
 class ClusterNotAvailable(ClusterCLIException):
     def __init__(self, msg):
         super(ClusterNotAvailable, self).__init__(msg)

--- a/pf9/cluster/exceptions.py
+++ b/pf9/cluster/exceptions.py
@@ -2,6 +2,7 @@
 Exceptions for Cluster Operations
 """
 from ..exceptions import CLIException
+from pf9.support.generate_bundle import Log_Bundle
 
 
 class ClusterCLIException(CLIException):
@@ -31,8 +32,11 @@ class ClusterCreateFailed(ClusterCLIException):
 
 
 class ClusterAttachFailed(ClusterCLIException):
-    def __init__(self, msg):
+    def __init__(self, msg,ctx,host):
         super(ClusterAttachFailed, self).__init__(msg)
+        support = Log_Bundle(msg)
+        support.create_log_bundle(ctx,'localhost')
+
 
 
 class ClusterNotAvailable(ClusterCLIException):
@@ -51,8 +55,10 @@ class FailedActiveMasters(ClusterCLIException):
 
 
 class PrepNodeFailed(ClusterCLIException):
-    def __init__(self, msg):
+    def __init__(self,msg,ctx,ips):
         super(PrepNodeFailed, self).__init__(msg)
+        support = Log_Bundle(msg)
+        support.check_host_status(ctx,ips) 
 
 
 class UserAuthFailure(CLIException):

--- a/pf9/cluster/exceptions.py
+++ b/pf9/cluster/exceptions.py
@@ -32,7 +32,7 @@ class ClusterCreateFailed(ClusterCLIException):
 
 
 class ClusterAttachFailed(ClusterCLIException):
-    def __init__(self, msg,ctx,host):
+    def __init__(self, msg):
         super(ClusterAttachFailed, self).__init__(msg)
 
 
@@ -52,10 +52,10 @@ class FailedActiveMasters(ClusterCLIException):
 
 
 class PrepNodeFailed(ClusterCLIException):
-    def __init__(self,msg,ctx,ips,user,password):
+    def __init__(self, msg, ctx, ips, user, password):
         super(PrepNodeFailed, self).__init__(msg)
         support = Log_Bundle(msg)
-        support.check_host_status(ctx,ips,user,password) 
+        support.check_host_status(ctx, ips, user, password) 
 
 
 class UserAuthFailure(CLIException):

--- a/pf9/cluster/exceptions.py
+++ b/pf9/cluster/exceptions.py
@@ -34,8 +34,7 @@ class ClusterCreateFailed(ClusterCLIException):
 class ClusterAttachFailed(ClusterCLIException):
     def __init__(self, msg,ctx,host):
         super(ClusterAttachFailed, self).__init__(msg)
-        support = Log_Bundle(msg)
-        support.create_log_bundle(ctx,'localhost')
+
 
 
 
@@ -55,10 +54,10 @@ class FailedActiveMasters(ClusterCLIException):
 
 
 class PrepNodeFailed(ClusterCLIException):
-    def __init__(self,msg,ctx,ips):
+    def __init__(self,msg,ctx,ips,user,password):
         super(PrepNodeFailed, self).__init__(msg)
         support = Log_Bundle(msg)
-        support.check_host_status(ctx,ips) 
+        support.check_host_status(ctx,ips,user,password) 
 
 
 class UserAuthFailure(CLIException):

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -171,7 +171,7 @@ def create(ctx, silent, host, offline, mgmt_plane):
                 log_upload_s3 = Log_Bundle()
                 Get(ctx).active_config()
                 du_url = ctx.params['du_url']
-                log_upload_s3.remote_host_upload(du_url,ssh_conn,host)
+                log_upload_s3.remote_host_upload(du_url, ssh_conn, host)
                 click.echo(ssh_result_bundle.stdout.strip())
                 # I don't like this exit point
                 # needs to return to bottom

--- a/pf9/support/commands.py
+++ b/pf9/support/commands.py
@@ -101,7 +101,6 @@ def bundle():
 @click.pass_context
 def create(ctx, silent, host, offline, mgmt_plane):
     """Request Creation of a Platform9 Support"""
-    #Get(ctx).active_config()
     if offline and mgmt_plane:
         click.echo("--mgmt-plane and --offline are not mutually exclusive.\n"
                    "Only one may be set")
@@ -199,7 +198,6 @@ def create(ctx, silent, host, offline, mgmt_plane):
                 ssh_conn = Connection(host=host,
                                       user=user_name,
                                       port=22,
-
                                       connect_kwargs=ssh_auth,
                                       config=config)
 

--- a/pf9/support/generate_bundle.py
+++ b/pf9/support/generate_bundle.py
@@ -1,0 +1,290 @@
+import os
+import sys
+import click
+import getpass
+import shlex
+import subprocess
+import requests
+import json
+from fabric import Connection, Config
+import paramiko.ssh_exception
+import socket
+import invoke.exceptions
+import time
+from progress.bar import Bar
+from pf9.exceptions import DUCommFailure, CLIException, UserAuthFailure
+from pf9.modules.express import Get
+from pf9.modules.util import Utils, Logger, Pf9ExpVersion
+
+
+logger = Logger(os.path.join(os.path.expanduser("~"), 'pf9/log/pf9ctl.log')).get_logger(__name__)
+
+class Log_Bundle:
+
+    def __init__(self,error_msg="none"):
+        self.error_msg = error_msg
+#       self.host = "127.0.0.1"
+
+    def get_uuid_from_resmgr(self,du_url,host_ip,headers):
+
+    #Based on the host_ip this function would pull the host UUID from resmgr.
+
+        try:
+            api_endpoint = "resmgr/v1/hosts"
+            pf9_response = requests.get("{}/{}".format(du_url,api_endpoint),
+                                        headers=headers)
+            if pf9_response.status_code != 200:
+                return None
+
+            # parse resmgr response
+            json_response = json.loads(pf9_response.text)
+        except Exception as except_err:
+            logger.exception(except_err)
+            return None
+
+        # sequentially search resmgr response for the ip of the host, if the ip is found return host uuid
+        for host in json_response:
+            try:
+                for iface_name, iface_ip in host['extensions']['interfaces']['data']['iface_ip'].items():
+                    if iface_ip == host_ip:
+                        logger.info("Node host_id: {}".format(host['id']))
+                        return host['id']
+            except Exception as e:
+                logger.exception(e)
+        return None
+
+    def check_host_status(self,ctx,ips):
+        """ Check the status of the host in Resource manager , obtaing the UUID and verify the role and responding status """
+        Get(ctx).active_config()
+        du_url = ctx.params['du_url']
+        token = ctx.params['token']
+        host_uuid = {}
+        headers = {'Content-Type': 'application/json', 'X-Auth-Token': token}
+
+        for host in ips:
+            #If the host provided is local host
+            # get ip of the localhost and get the hostname
+
+            if host in ['127.0.0.1','localhost']:
+                hostname=socket.gethostname()
+                ip=socket.gethostbyname(hostname)
+            # get host uuid from resmgr using the ip of the localhost
+                host_uuid[ip]=self.get_uuid_from_resmgr(du_url,ip,headers)
+
+                if host_uuid[ip]:
+                # if a valid uuid is found , hostagent is configured and we can pull the support bundle from the host
+                    resmgr_endpoint = '{}/resmgr/v1/hosts/{}'.format(ctx.params['du_url'],host_uuid[ip])
+
+                    resmgr_get_hosts = requests.get(resmgr_endpoint,verify=False,headers=headers)
+                    data = resmgr_get_hosts.json()
+                    roles = (data["roles"])
+                    responding = (data["info"]["responding"])
+
+                    if responding and roles[0] == "pf9-kube":
+                        pass
+                    else:
+                        click.secho("PF9 Installation failed for the host: {}\n".format(host))
+                        time.sleep(2)
+                        self.create_log_bundle(ctx,host)
+                else:
+                # if a valid uuid not found in resmgr from the host , hostganet is not installled and support bunndle cant be generated
+                # uploading pf9ctl logs in this case
+                    answer = click.prompt ("pf9ctl Prep-Node failed. Do you want to share pf9ctl logs with Platform9 (y/n)", default='y')
+                    if answer == "y" or answer == "yes":
+                        self.upload_pf9cli_logs (du_url,host)
+                    else:
+                        click.secho("pf9ctl Prep-Node failed. Contact Platform9 Support at <support@platform9.com>")
+
+
+
+            # host provided in not localhost, get host uuid from resmgr using the ip
+            else:
+                host_uuid[host]=self.get_uuid_from_resmgr(du_url,host,headers)
+                if host_uuid[host]:
+                    resmgr_endpoint = '{}/resmgr/v1/hosts/{}'.format(ctx.params['du_url'],host_uuid[host])
+
+                    resmgr_get_hosts = requests.get(resmgr_endpoint,verify=False,headers=headers)
+                    data = resmgr_get_hosts.json()
+                    roles = (data["roles"])
+
+                    responding = (data["info"]["responding"])
+
+                    if responding and roles[0] == "pf9-kube":
+                        pass
+                    else:
+                        self.create_log_bundle(ctx,host)
+                else:
+                # if a valid uuid not found in resmgr from the host , hostganet is not installled and support bunndle cant be generated
+                # uploading pf9ctl logs in this case
+                    click.secho ("pf9ctl Prep-Node failed for node: {} \npf9ctl logs will be shared with Platform9 now\n".format(host), fg="red")
+                    self.upload_pf9cli_logs (du_url,host)
+
+
+        return None
+
+    def upload_pf9cli_logs (self,du_url,host):
+    #function for uploading pf9cli logs in case support bundle cant be generated
+        log_path = str(self.error_msg)
+        filename = log_path.split(":")[2].lstrip()
+        #host = socket.getfqdn()    ## Made changes as we are now getting host information in parameter: host
+        du_url = du_url.replace("https://","")
+#        filename = path.replace("Code: 4, output log: ","")
+        S3_location = "http://uploads.platform9.com.s3-us-west-1.amazonaws.com/"+str(du_url)+"/"+str(host)+"/"
+        try:
+
+            click.secho("Uploading the pf9cli log file {}\n".format(filename),fg="green")
+            with Bar('Uploading', max=100) as bar:
+                for i in range(100):
+                    cmd = subprocess.run(["curl", "-T", filename, S3_location])
+                    # self.create_os_information(S3_location)
+                    bar.next()
+            #time.sleep(2)
+            click.secho("\nUploaded the pf9cli log files at {}".format(S3_location),
+                        fg="green")
+        except Exception as e:
+           click.secho(e)
+           click.secho("File uploading failed with error")
+
+        return None
+
+    def create_log_bundle(self,ctx,host='none'):
+
+        #This function is used to generate the log bundle based on the host ip.
+
+        Get(ctx).active_config()
+        du_url = ctx.params['du_url']
+        ips = ctx.params['ips']
+        upload_logs =  True
+        use_localhost = False
+        click.secho("Generating support bundle for the host {}".format(host), fg='green')
+        datagatherer_py3 = '/opt/pf9/hostagent/lib/python3.6/site-packages/datagatherer/datagatherer.py'
+        datagatherer_py2 = '/opt/pf9/hostagent/lib/python2.7/site-packages/datagatherer/datagatherer.py'
+        if os.path.isfile(datagatherer_py3):
+            bundle_exec = 'python {}'.format(datagatherer_py3)
+        elif os.path.isfile(datagatherer_py2):
+            bundle_exec = 'python {}'.format(datagatherer_py2)
+        else:
+            # Just attempt the py3 path (and fail if it doesn't exist)
+            bundle_exec = 'python {}'.format(datagatherer_py3)
+        if not host or host in ['localhost', '127.0.0.1']:
+
+                host = socket.getfqdn()
+                try:
+#                   Generating support bundle on localhost
+                    subprocess.check_output(shlex.split("sudo " + bundle_exec))
+                    check_bundle_out = subprocess.check_output(shlex.split("sudo ls -sh /tmp/pf9-support.tgz"))
+                    if check_bundle_out:
+                        click.echo("Generation of support bundle complete on Host:".format(host))
+                        click.echo(check_bundle_out)
+                        #upload_logs=click.prompt("Do you want to send the logs files to Platform9: ?(y,n)", default='y')
+                        #if upload_logs.lower() == 'y' or upload_logs.lower() == 'yes':
+                        click.secho("Sending the Support Bundle to Platform9",fg='green')
+                        time.sleep(2)
+                        self.upload_logs(du_url)
+                        #else:
+                        #click.secho("Logs not uploaded", fg='red')
+                        # exit(0)
+                    #else:
+                    #    click.echo("Support Bundle Creation Failed,Sending pf9ctl logs to Platform9")
+                        # upload only pf9ctl logs
+                except subprocess.CalledProcessError as except_err:
+                    click.echo("Support Bundle Creation Failed:")
+                    # upload only pf9ctl logs
+
+        else:
+        # Generating support Bundle for remote Host
+            click.secho("Generating support bundle for the host "+host+" via passwordless SSH")
+            ssh_dir = os.path.join(os.path.expanduser("~"), '.ssh/id_rsa')
+            user_name = getpass.getuser()
+            ssh_conn = Connection(host=host,
+                                      user=user_name,
+                                      port=22)
+            attempt = 0
+            while attempt < 3:
+                attempt = attempt + 1
+                try:
+                    ssh_result_generate = ssh_conn.sudo(bundle_exec, hide='stderr')
+                    ssh_result_bundle = ssh_conn.sudo('ls -sh /tmp/pf9-support.tgz', hide='stderr')
+                    if ssh_result_generate.exited and ssh_result_bundle.exited:
+                        ssh_conn.close()
+                    click.echo("\n\n")
+                    click.echo("Generation of support bundle completed on Host: " + host +"\n")
+                    click.echo(ssh_result_bundle.stdout.strip())
+                    click.secho("Sending the Support Bundle to Platform9",fg='green')
+                    time.sleep(2)
+                    self.remote_host_upload(du_url, ssh_conn, host)
+                    break
+
+
+                except paramiko.ssh_exception.NoValidConnectionsError:
+                        click.echo("Unable to communicate with: " + host)
+                        sys.exit(1)
+                #If passwordless ssh is not configured to a host , ask for username and password to generate the bundle
+                except (paramiko.ssh_exception.SSHException,paramiko.ssh_exception.PasswordRequiredException,invoke.exceptions.AuthFailure) as err:
+                        click.secho("Password less SSH for the"+host+" didn't work.\nNeed credentials for the host")
+                        click.echo("\nAttempt [{}/3]".format(attempt))
+                        click.echo("SSH Credentials for {}".format(host))
+                        user_name = click.prompt("Username {}".format(user_name), default=user_name)
+                        #use_ssh_key = click.prompt("Use SSH Key Auth? [y/n]", default='y')
+                        #if use_ssh_key.lower() == 'y':
+                        #   ssh_key_file = click.prompt("SSH private key file: ", default=ssh_dir)
+                        #   ssh_auth = {"look_for_keys": "false", "key_filename": ssh_key_file}
+
+                        password = getpass.unix_getpass()
+                        ssh_auth = {"look_for_keys": "false", "password": password}
+                        #click.echo("Sudo ", nl=False)
+                        #sudo_pass = getpass.unix_getpass()
+                        #config = Config(overrides={'sudo': {'password': sudo_pass}})
+                        config = {'password': password}
+                        ssh_conn = Connection(host=host,
+                                              user=user_name,
+                                              port=22,
+                                              connect_kwargs=config)
+        return None
+
+
+
+    def upload_logs(self,du_url):
+    # function to upload the logs from the localhost to S3
+        host = socket.getfqdn()
+        du_url = du_url.replace("https://","")
+        filename = "/tmp/pf9-support.tgz"
+#        filename = path.replace("Code: 4, output log: ","")
+        S3_location = "http://uploads.platform9.com.s3-us-west-1.amazonaws.com/"+str(du_url)+"/"+str(host)+"/"
+        try:
+#            f = open(filename)
+#            print ("\n")
+            click.secho("Uploading the log file & system information {} to {}\n".format(filename,S3_location),fg="green")
+            with Bar('Uploading', max=100) as bar:
+                for i in range(100):
+                    cmd = subprocess.run(["curl", "-T", filename, S3_location])
+                    # self.create_os_information(S3_location)
+                    bar.next()
+            #time.sleep(2)
+            click.secho("\nUploaded the files at {}\n".format(S3_location),
+                        fg="green")
+        except Exception as e:
+           click.secho(e)
+           click.secho("File uploading failed with error\n")
+
+        return None
+
+
+
+    def remote_host_upload(self,du_url,ssh_conn,host):
+    # function to upload the logs from remote host to S3
+        S3_location = "http://uploads.platform9.com.s3-us-west-1.amazonaws.com/"+str(du_url)+"/"+str(host)+"/"
+        du_url = du_url.replace("https://","")
+        filename = "/tmp/pf9-support.tgz"
+        try:
+            click.secho("Uploading the log file & system information {} to {}\n".format(filename,S3_location),fg="green")
+           # with Bar('Uploading', max=100) as bar:
+           #     for i in range(100):
+            ssh_conn.sudo("curl -s -T /tmp/pf9-support.tgz http://uploads.platform9.com.s3-us-west-1.amazonaws.com/"+du_url+"/"+host+"/")
+           #          bar.next()
+            click.secho("\n Uploaded the files to S3\n")
+
+        except Exception as e:
+            click.secho(e)
+            click.secho("File uploading failed with error\n")
+        return None

--- a/pf9/support/generate_bundle.py
+++ b/pf9/support/generate_bundle.py
@@ -23,25 +23,20 @@ class Log_Bundle:
 
     def __init__(self,error_msg="none"):
         self.error_msg = error_msg
-#       self.host = "127.0.0.1"
-        
-    def get_uuid_from_resmgr(self,du_url,host_ip,headers): 
 
+    def get_uuid_from_resmgr(self,du_url,host_ip,headers):
     #Based on the host_ip this function would pull the host UUID from resmgr.
-        
         try:
             api_endpoint = "resmgr/v1/hosts"
             pf9_response = requests.get("{}/{}".format(du_url,api_endpoint),
                                         headers=headers)
             if pf9_response.status_code != 200:
                 return None
-
             # parse resmgr response
             json_response = json.loads(pf9_response.text)
         except Exception as except_err:
             logger.exception(except_err)
             return None
-
         # sequentially search resmgr response for the ip of the host, if the ip is found return host uuid
         for host in json_response:
             try:
@@ -53,121 +48,79 @@ class Log_Bundle:
                 logger.exception(e)
         return None
 
-    def check_host_status(self,ctx,ips):
+    def check_host_status(self,ctx,ips,user,password):
         """ Check the status of the host in Resource manager , obtaing the UUID and verify the role and responding status """
         Get(ctx).active_config()
         du_url = ctx.params['du_url']
         token = ctx.params['token']
         host_uuid = {}
         headers = {'Content-Type': 'application/json', 'X-Auth-Token': token}
-
         for host in ips:
-            #If the host provided is local host 
-            # get ip of the localhost and get the hostname 
-            
-            if host in ['127.0.0.1','localhost']: 
-                hostname=socket.gethostname()  
-                ip=socket.gethostbyname(hostname)  
-            # get host uuid from resmgr using the ip of the localhost 
+            #If the host provided is local host
+            # get ip of the localhost and get the hostname
+            if host in ['127.0.0.1','localhost']:
+                hostname=socket.gethostname()
+                ip=socket.gethostbyname(hostname)
+            # get host uuid from resmgr using the ip of the localhost
                 host_uuid[ip]=self.get_uuid_from_resmgr(du_url,ip,headers)
-              
-                if host_uuid[ip]: 
-                # if a valid uuid is found , hostagent is configured and we can pull the support bundle from the host    
+
+                if host_uuid[ip]:
+                # if a valid uuid is found , hostagent is configured and we can pull the support bundle from the host
                     resmgr_endpoint = '{}/resmgr/v1/hosts/{}'.format(ctx.params['du_url'],host_uuid[ip])
-                  
                     resmgr_get_hosts = requests.get(resmgr_endpoint,verify=False,headers=headers)
                     data = resmgr_get_hosts.json()
                     roles = (data["roles"])
-                    #responding = (data["info"]["responding"])
-
                     if len(roles) >= 1 :
                         if roles[0] == "pf9-kube" and data["info"]["responding"] == "true":  # Responding key will only be there is pf9-kube is installed else there will not be any responding key in response
-                            pass 
+                            pass
                         else:
-                            click.secho("PF9 Installation failed for the host: {}\n".format(host))
-                            time.sleep(2)                            
-                            self.create_log_bundle(ctx,host)
+                            time.sleep(2)
+                            self.create_log_bundle(ctx,user,password,host)
                     else:
-                        click.secho("PF9 Installation failed for the host: {}\n".format(host))
                         time.sleep(2)
-                        self.create_log_bundle(ctx,host)
+                        self.create_log_bundle(ctx,user,password,host)
                 else:
-                # if a valid uuid not found in resmgr from the host , hostganet is not installled and support bunndle cant be generated 
-                # uploading pf9ctl logs in this case 
-                    answer = click.prompt ("pf9ctl Prep-Node failed. Do you want to share pf9ctl logs with Platform9 (y/n)", default='y')
-                    if answer == "y" or answer == "yes":
-                        self.upload_pf9cli_logs (du_url,host)
-                    else:
-                        click.secho("pf9ctl Prep-Node failed. Contact Platform9 Support at <support@platform9.com>")
-
-
-            
-            # host provided in not localhost, get host uuid from resmgr using the ip
-            else: 
-                host_uuid[host]=self.get_uuid_from_resmgr(du_url,host,headers)
-                if host_uuid[host]: 
-                    resmgr_endpoint = '{}/resmgr/v1/hosts/{}'.format(ctx.params['du_url'],host_uuid[host])
-                  
-                    resmgr_get_hosts = requests.get(resmgr_endpoint,verify=False,headers=headers)
-                    data = resmgr_get_hosts.json()
-                    
-                    roles = (data["roles"])
-                
-                    #responding = (data["info"]["responding"])
-
-                    if len(roles) >= 1:
-                        if roles[0] == "pf9-kube" and data["info"]["responding"] == "true": # Responding key will only be there is pf9-kube is installed else there will not be any responding key in response
-                            pass 
-                        else:
-                            self.create_log_bundle(ctx,host)       
-                    else:
-                        self.create_log_bundle(ctx,host)
-                else:
-                # if a valid uuid not found in resmgr from the host , hostganet is not installled and support bunndle cant be generated 
-                # uploading pf9ctl logs in this case
-                    click.secho ("\n\npf9ctl Prep-Node failed for node: {} \npf9ctl logs will be shared with Platform9 now\n".format(host), fg="red")
                     self.upload_pf9cli_logs (du_url,host)
 
+            # host provided in not localhost, get host uuid from resmgr using the ip
+            else:
+                host_uuid[host]=self.get_uuid_from_resmgr(du_url,host,headers)
+                if host_uuid[host]:
+                    resmgr_endpoint = '{}/resmgr/v1/hosts/{}'.format(ctx.params['du_url'],host_uuid[host])
+                    resmgr_get_hosts = requests.get(resmgr_endpoint,verify=False,headers=headers)
+                    data = resmgr_get_hosts.json()
+                    roles = (data["roles"])
+                    if len(roles) >= 1:
+                        if roles[0] == "pf9-kube" and data["info"]["responding"] == "true": # Responding key will only be there is pf9-kube is installed else there will not be any responding key in response
+                            pass
+                        else:
+                            self.create_log_bundle(ctx,user,password,host)
+                    else:
+                        self.create_log_bundle(ctx,user,password,host)
+                else:
+                # if a valid uuid not found in resmgr from the host , hostganet is not installled and support bunndle cant be generated
+                # uploading pf9ctl logs in this case
+                    self.upload_pf9cli_logs (du_url,host)
 
-        return None          
+        return None
 
     def upload_pf9cli_logs (self,du_url,host):
-    #function for uploading pf9cli logs in case support bundle cant be generated 
+    #function for uploading pf9cli logs in case support bundle cant be generated
         log_path = str(self.error_msg)
         filename = log_path.split(":")[2].lstrip()
         cli_logs="/root/pf9/log/pf9ctl.log"
-        #host = socket.getfqdn()    ## Made changes as we are now getting host information in parameter: host
         du_url = du_url.replace("https://","")
-#        filename = path.replace("Code: 4, output log: ","")
         S3_location = "https://sheda-pf9ctl-log-testing.s3-us-west-1.amazonaws.com/"+str(du_url)+"/"+str(host)+"/"
-        try:
-             
-            click.secho("Uploading the pf9cli log file {}\n".format(filename),fg="green")
-            with Bar('Uploading', max=100) as bar:
-                for i in range(100):
-                    cmd = subprocess.run(["curl", "-T", filename, S3_location])
-                    cmd = subprocess.run(["curl", "-T", cli_logs, S3_location])
-                    # self.create_os_information(S3_location)
-                    bar.next()
-            #time.sleep(2)
-            click.secho("\nUploaded the pf9ctl log files at {}".format(S3_location),
-                        fg="green")
-        except Exception as e:
-           click.secho(e)
-           click.secho("File uploading failed with error")
-        
+        cmd = subprocess.run(["curl", "-T", filename, S3_location])
+        cmd = subprocess.run(["curl", "-T", cli_logs, S3_location])
         return None
 
-    def create_log_bundle(self,ctx,host='none'):
-
+    def create_log_bundle(self,ctx,user,password,host='none'):
         #This function is used to generate the log bundle based on the host ip.
-
         Get(ctx).active_config()
         du_url = ctx.params['du_url']
-        #ips = ctx.params['ips']     
         upload_logs =  True
         use_localhost = False
-        click.secho("\nGenerating support bundle for the host {}".format(host), fg='green')
         datagatherer_py3 = '/opt/pf9/hostagent/lib/python3.6/site-packages/datagatherer/datagatherer.py'
         datagatherer_py2 = '/opt/pf9/hostagent/lib/python2.7/site-packages/datagatherer/datagatherer.py'
         if os.path.isfile(datagatherer_py3):
@@ -178,128 +131,86 @@ class Log_Bundle:
             # Just attempt the py3 path (and fail if it doesn't exist)
             bundle_exec = 'python {}'.format(datagatherer_py3)
         if not host or host in ['localhost', '127.0.0.1']:
-
                 host = socket.getfqdn()
-                try:
-#                   Generating support bundle on localhost
-                    subprocess.check_output(shlex.split("sudo " + bundle_exec))
-                    check_bundle_out = subprocess.check_output(shlex.split("sudo ls -sh /tmp/pf9-support.tgz"))
-                    if check_bundle_out:
-                        click.echo("Generation of support bundle complete on Host:".format(host))
-                        click.echo(check_bundle_out)
-                        #upload_logs=click.prompt("Do you want to send the logs files to Platform9: ?(y,n)", default='y')
-                        #if upload_logs.lower() == 'y' or upload_logs.lower() == 'yes':
-                        click.secho("Sending the Support Bundle to Platform9",fg='green')
-                        time.sleep(2)
-                        self.upload_logs(du_url)
-                        self.upload_pf9cli_logs(du_url,host)
-                        #else:
-                        #click.secho("Logs not uploaded", fg='red')
-                        # exit(0)
-                    #else:
-                    #    click.echo("Support Bundle Creation Failed,Sending pf9ctl logs to Platform9")
-                        # upload only pf9ctl logs 
-                except subprocess.CalledProcessError as except_err:
-                    click.echo("Support Bundle Creation Failed:")
-                    # upload only pf9ctl logs 
-            
+#               Generating support bundle on localhost
+                subprocess.check_output(shlex.split("sudo " + bundle_exec))
+                check_bundle_out = subprocess.check_output(shlex.split("sudo ls -sh /tmp/pf9-support.tgz"))
+                if check_bundle_out:
+                    time.sleep(2)
+                    self.upload_logs(du_url)
+                    self.upload_pf9cli_logs(du_url,host)
+
         else:
-        # Generating support Bundle for remote Host 
-            click.secho("\nGenerating support bundle for the host "+host+" via passwordless SSH", fg="green")
+        # Generating support Bundle for remote Host
             ssh_dir = os.path.join(os.path.expanduser("~"), '.ssh/id_rsa')
             user_name = getpass.getuser()
             ssh_conn = Connection(host=host,
                                       user=user_name,
                                       port=22)
-            attempt = 0
-            while attempt < 3:
-                attempt = attempt + 1
-                try:
-                    ssh_result_generate = ssh_conn.sudo(bundle_exec, hide='stderr')
-                    ssh_result_bundle = ssh_conn.sudo('ls -sh /tmp/pf9-support.tgz', hide='stderr')
-                    if ssh_result_generate.exited and ssh_result_bundle.exited:
-                        ssh_conn.close()
-                    click.echo("\n\n")
-                    click.echo("Generation of support bundle completed on Host: " + host +"\n")
-                    click.echo(ssh_result_bundle.stdout.strip())
-                    click.secho("Sending the Support Bundle to Platform9",fg='green')
-                    time.sleep(2)
-                    self.remote_host_upload(du_url, ssh_conn, host)
+#           attempt = 0
+#            while attempt < 3:
+#                attempt = attempt + 1
+            try:
+                ssh_result_generate = ssh_conn.sudo(bundle_exec, hide='stderr')
+                ssh_result_bundle = ssh_conn.sudo('ls -sh /tmp/pf9-support.tgz', hide='stderr')
+                if ssh_result_generate.exited and ssh_result_bundle.exited:
+                    ssh_conn.close()
+                click.echo("\n\n")
+                #click.echo("Generation of support bundle completed on Host: " + host +"\n")
+                #click.echo(ssh_result_bundle.stdout.strip())
+                time.sleep(2)
+                self.remote_host_upload(du_url, ssh_conn, host)
+                self.upload_pf9cli_logs(du_url,host)
+
+
+
+            except paramiko.ssh_exception.NoValidConnectionsError:
                     self.upload_pf9cli_logs(du_url,host)
-                    break
-
-
-                except paramiko.ssh_exception.NoValidConnectionsError:
-                        click.echo("Unable to communicate with: " + host)
-                        sys.exit(1)
-                #If passwordless ssh is not configured to a host , ask for username and password to generate the bundle          
-                except (paramiko.ssh_exception.SSHException,paramiko.ssh_exception.PasswordRequiredException,invoke.exceptions.AuthFailure) as err:
-                        click.secho("\nPassword less SSH for the node: "+host+" didn't work.\nNeed credentials for the host",fg="red")
-                        click.echo("\nAttempt [{}/3]".format(attempt))
-                        click.echo("SSH Credentials for {}".format(host))
-                        user_name = click.prompt("Username {}".format(user_name), default=user_name)
-                        #use_ssh_key = click.prompt("Use SSH Key Auth? [y/n]", default='y')
-                        #if use_ssh_key.lower() == 'y':
-                        #   ssh_key_file = click.prompt("SSH private key file: ", default=ssh_dir)
-                        #   ssh_auth = {"look_for_keys": "false", "key_filename": ssh_key_file}
-
-                        password = getpass.unix_getpass()
-                        ssh_auth = {"look_for_keys": "false", "password": password}
-                        #click.echo("Sudo ", nl=False)
-                        #sudo_pass = getpass.unix_getpass()
-                        #config = Config(overrides={'sudo': {'password': sudo_pass}})
-                        config = {'password': password}
+                    sys.exit(1)
+                #If passwordless ssh is not configured to a host , ask for username and password to generate the bundle
+            except (paramiko.ssh_exception.SSHException,paramiko.ssh_exception.PasswordRequiredException,invoke.exceptions.AuthFailure) as err:
+#                    click.secho("\nPassword less SSH for the node: "+host+" didn't work.\nNeed credentials for the host",fg="red")
+#                    click.echo("\nAttempt [{}/3]".format(attempt))
+#                    click.echo("SSH Credentials for {}".format(host))
+                    user_name = user
+                    password = password
+                    ssh_auth = {"look_for_keys": "false", "password": password}
+                    config = {'password': password}
+                    try:
                         ssh_conn = Connection(host=host,
                                               user=user_name,
                                               port=22,
                                               connect_kwargs=config)
+                        ssh_result_generate = ssh_conn.sudo(bundle_exec, hide='stderr')
+                        ssh_result_bundle = ssh_conn.sudo('ls -sh /tmp/pf9-support.tgz', hide='stderr')
+                        if ssh_result_generate.exited and ssh_result_bundle.exited:
+                           ssh_conn.close()
+                        click.echo("\n\n")
+                        time.sleep(2)
+                        self.remote_host_upload(du_url, ssh_conn, host)
+                        self.upload_pf9cli_logs(du_url,host)
+                    except (paramiko.ssh_exception.SSHException,paramiko.ssh_exception.PasswordRequiredException,invoke.exceptions.AuthFailure) as err:
+                        self.upload_pf9cli_logs(du_url,host)
+
         return None
 
 
 
     def upload_logs(self,du_url):
-    # function to upload the logs from the localhost to S3
+    #function to upload the logs from the localhost to S3
         host = socket.getfqdn()
         du_url = du_url.replace("https://","")
         filename = "/tmp/pf9-support.tgz"
-        
-#        filename = path.replace("Code: 4, output log: ","")
         S3_location = "https://sheda-pf9ctl-log-testing.s3-us-west-1.amazonaws.com/"+str(du_url)+"/"+str(host)+"/"
-        try:
-#            f = open(filename)
-#            print ("\n")
-            click.secho("Uploading the log file & system information {} to {}\n".format(filename,S3_location),fg="green")
-            with Bar('Uploading', max=100) as bar:
-                for i in range(100):
-                    cmd = subprocess.run(["curl", "-T", filename, S3_location])
-                    # self.create_os_information(S3_location)
-                    bar.next()
-            #time.sleep(2)
-            click.secho("\nUploaded the files at {}\n".format(S3_location),
-                        fg="green")
-        except Exception as e:
-           click.secho(e)
-           click.secho("File uploading failed with error\n")
-        
-        return None 
+        cmd = subprocess.run(["curl", "-T", filename, S3_location])
+        return None
 
 
 
     def remote_host_upload(self,du_url,ssh_conn,host):
-    # function to upload the logs from remote host to S3  
+    # function to upload the logs from remote host to S3
         du_url = du_url.replace("https://","")
         S3_location = "https://sheda-pf9ctl-log-testing.s3-us-west-1.amazonaws.com/"+str(du_url)+"/"+str(host)+"/"
-        
         filename = "/tmp/pf9-support.tgz"
-        try: 
-            click.secho("Uploading the log file & system information {} to {}\n".format(filename,S3_location),fg="green")
-           # with Bar('Uploading', max=100) as bar:
-           #     for i in range(100):
-            ssh_conn.sudo("curl -s -T /tmp/pf9-support.tgz https://sheda-pf9ctl-log-testing.s3-us-west-1.amazonaws.com/"+du_url+"/"+host+"/")         
-           #          bar.next()
-            
-
-        except Exception as e:
-            click.secho(e)
-            click.secho("File uploading failed with error\n")
+        ssh_conn.sudo("curl -s -T /tmp/pf9-support.tgz https://sheda-pf9ctl-log-testing.s3-us-west-1.amazonaws.com/"+du_url+"/"+host+"/")
         return None


### PR DESCRIPTION
Added logic to upload pf9ctl logs and support bundle to S3 bucket: https://console.aws.amazon.com/s3/buckets/sheda-pf9ctl-log-testing (bucket created for testing) on prep-node failure.

A support bundle would be created if the pf9-hostagent package is installed else pf9ctl logs will be collected and uploaded to S3.