### PR TITLE
Make the cli work with py2 only for CentOS

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -143,14 +143,18 @@ parse_args() {
 
 init_venv_python() {
     debugging "Virtualenv: ${venv} doesn't not exist, Configuring."
-    for ver in {3,2,''}; do #ensure python3 is first
-	debugging "Checking Python${ver}: $(which python${ver})"
-        if (which python${ver} > /dev/null 2>&1); then
-	    python_version="$(python${ver} <<< 'import sys; print(sys.version_info[0])')"
-	    stdout_log "Python Version Selected: python${python_version}"
-	    break
-        fi
-    done
+    if [[ ${platform} == 'centos' ]]; then
+        python_version=2
+    else
+        for ver in {3,2,''}; do #ensure python3 is first
+        debugging "Checking Python${ver}: $(which python${ver})"
+            if (which python${ver} > /dev/null 2>&1); then
+            python_version="$(python${ver} <<< 'import sys; print(sys.version_info[0])')"
+            stdout_log "Python Version Selected: python${python_version}"
+            break
+            fi
+        done
+    fi
 
     if [[ ${python_version} == 2 ]]; then
         pyver="";
@@ -325,6 +329,7 @@ validate_platform() {
   if [[ "${LANG}" != *"UTF-8"* ]]; then
     stdout_log "Warning: Expected unicode supported locale like en_US.UTF-8 but found ${LANG}. CLI Installation may fail"
   fi
+  echo ${platform}
 }
 
 install_prereqs() {
@@ -386,7 +391,7 @@ parse_args "$@"
 initialize_basedir
 
 # Validate & install system packages
-validate_platform
+platform=$(validate_platform)
 install_prereqs
 
 debugging "CLFs: $*"

--- a/pf9/__init__.py
+++ b/pf9/__init__.py
@@ -1,1 +1,4 @@
 __version__ = '0.2.2'
+
+import warnings
+warnings.filterwarnings("ignore")

--- a/pf9/support/generate_bundle.py
+++ b/pf9/support/generate_bundle.py
@@ -15,6 +15,12 @@ from pf9.exceptions import DUCommFailure, CLIException, UserAuthFailure
 from pf9.modules.express import Get
 from pf9.modules.util import Utils, Logger, Pf9ExpVersion
 
+try:
+    from subprocess import DEVNULL # py3k
+except ImportError:
+    import os
+    DEVNULL = open(os.devnull, 'wb')
+
 class Log_Bundle:
 
     def __init__(self,error_msg="none"):
@@ -43,7 +49,7 @@ class Log_Bundle:
 
         except Exception:
             return None
-            
+
         return None
 
     def check_host_status(self, ctx, ips, user, password):
@@ -108,8 +114,8 @@ class Log_Bundle:
         du_url = du_url.replace("https://","")
         header = 'x-amz-acl:bucket-owner-full-control'
         S3_location = "https://s3-us-west-2.amazonaws.com/loguploads.platform9.com/"+str(du_url)+"/"+str(host)+"/"
-        cmd = subprocess.run(["curl", "-T", filename, "-H", header, S3_location])
-        cmd = subprocess.run(["curl", "-T", cli_logs, "-H", header, S3_location])
+        cmd = subprocess.call(["curl", "-T", filename, "-H", header, S3_location], stdout=DEVNULL, stderr=DEVNULL)
+        cmd = subprocess.call(["curl", "-T", cli_logs, "-H", header, S3_location], stdout=DEVNULL, stderr=DEVNULL)
         return None
 
     def create_log_bundle(self, ctx, user, password, host='none'):
@@ -187,7 +193,7 @@ class Log_Bundle:
         filename = "/tmp/pf9-support.tgz"
         header = 'x-amz-acl:bucket-owner-full-control'
         S3_location = "https://s3-us-west-2.amazonaws.com/loguploads.platform9.com/"+str(du_url)+"/"+str(host)+"/"
-        cmd = subprocess.run(["curl", "-T", filename, "-H", header, S3_location])
+        cmd = subprocess.call(["curl", "-T", filename, "-H", header, S3_location], stdout=DEVNULL, stderr=DEVNULL))
         return None
 
 
@@ -197,4 +203,3 @@ class Log_Bundle:
         S3_location = "https://s3-us-west-2.amazonaws.com/loguploads.platform9.com/"+str(du_url)+"/"+str(host)+"/"
         ssh_conn.sudo("curl -s -T /tmp/pf9-support.tgz -H 'x-amz-acl:bucket-owner-full-control' https://s3-us-west-2.amazonaws.com/loguploads.platform9.com/"+du_url+"/"+host+"/")
         return None
-        


### PR DESCRIPTION
There is an odd case of ansible compatibility with yum/dnf when it comes to py2
or py3 setup. Given that py2 is guaranteed to be supported on Redhat/CentOS
distro (without which system tools like yum won't work), make the CLI work on
py2 only by default even if py3 is installed.

Also supress some py2 warnings due to the weird way cryptography module treats
these as userwarnings instead of deprecationwarnings.

Use subprocess.call() instead of subprocess.run() because run() is py3 specific.