### PR TITLE
Use get-pip.py specific for python2.7

### DIFF
--- a/cli-setup.sh
+++ b/cli-setup.sh
@@ -460,7 +460,7 @@ debugging "cli_url: ${cli_url}"
 pip_path=${pf9_basedir}/get_pip.py
 venv_python="${venv}/bin/python"
 venv_activate="${venv}/bin/activate"
-pip_url="https://bootstrap.pypa.io/get-pip.py"
+pip_url="https://bootstrap.pypa.io/2.7/get-pip.py"
 cli_entrypoint=$(dirname ${venv_python})/express
 cli_exec=${pf9_bin}/pf9ctl
 pf9_bash_profile=${pf9_bin}/pf9-bash-profile.sh


### PR DESCRIPTION
Pip 21.0 dropped support for python3.5 in Jan 2021 since it is deprecated. Python3.5 is the default python3 version on CentOS7 and Ubuntu16. Pinning the URL to python2.7 compatible script as it works with both python3.5 and python2.7. 